### PR TITLE
fix available flash size for 2M

### DIFF
--- a/src/config.esp
+++ b/src/config.esp
@@ -68,6 +68,7 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 		rfidss = hardware["sspin"];
 		setupPN532Reader(rfidss);
 	}
+	if (readerType>2) Serial.begin(9600);
 #endif
 	autoRestartIntervalSeconds = general["restart"];
 	wifiTimeout = network["offtime"];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ int relayPin = 13;
 MFRC522 mfrc522 = MFRC522();
 PN532 pn532;
 WIEGAND wg;
-RFID_Read RFIDr;
+RFID_Reader RFIDr;
 
 int rfidss;
 int readerType;

--- a/src/rfid125kHz.cpp
+++ b/src/rfid125kHz.cpp
@@ -1,8 +1,31 @@
 /*
 RFID reader.
-Based on the "rfid_reader" library (https://github.com/travisfarmer) from Travis Farmer.
+Based on the "RFID_Readerer" library (https://github.com/travisfarmer) from Travis Farmer.
 
-Author: Lubos Ruckl
+==================================================================
+Copyright (c) 2018 Lubos Ruckl
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+==================================================================
 
 Hardware: RDM6300 or RF125-PS
 Uses 125KHz RFID tags.
@@ -11,7 +34,7 @@ Uses 125KHz RFID tags.
 #include "Arduino.h"
 #include "rfid125kHz.h"
 
-char *RFID_Read::ulltostr(unsigned long long value, char *ptr, int base)
+char *RFID_Reader::ulltostr(unsigned long long value, char *ptr, int base)
 {
   unsigned long long t = 0, res = 0;
   unsigned long long tmp = value;
@@ -50,7 +73,7 @@ char *RFID_Read::ulltostr(unsigned long long value, char *ptr, int base)
 this is to simply return true when there is RFID data available.
 it is a function to prevent external manipulation of the boolean variable.
 */
-bool RFID_Read::Available()
+bool RFID_Reader::Available()
 {
     return (data_available);
 }
@@ -58,7 +81,7 @@ bool RFID_Read::Available()
 /*
 Returns the ID hexadecimal representation, and resets the Available flag.
 */
-String RFID_Read::GetHexID()
+String RFID_Reader::GetHexID()
 {
     if (data_available)
     {
@@ -75,7 +98,7 @@ String RFID_Read::GetHexID()
 /*
 Returns the ID decimal representation, and resets the Available flag.
 */
-String RFID_Read::GetDecID()
+String RFID_Reader::GetDecID()
 {
     if (data_available)
     {
@@ -88,7 +111,7 @@ String RFID_Read::GetDecID()
 }
 
 
-void RFID_Read::rfidSerial(char x)
+void RFID_Reader::rfidSerial(char x)
 {
     if (x == StartByte)
     {
@@ -107,7 +130,7 @@ void RFID_Read::rfidSerial(char x)
 }
 
 
-uint8_t RFID_Read::get_checksum(unsigned long long data)
+uint8_t RFID_Reader::get_checksum(unsigned long long data)
   {
     uint8_t b[5];
     memcpy(b, &data, 5);
@@ -115,7 +138,7 @@ uint8_t RFID_Read::get_checksum(unsigned long long data)
   }
 
 
-uint8_t RFID_Read::char2int(char c)
+uint8_t RFID_Reader::char2int(char c)
   {
     c -= asciiNum_diff;
     if(c > 9) c -= asciiUpp_diff;
@@ -126,7 +149,7 @@ uint8_t RFID_Read::char2int(char c)
 /*
 the module spits out HEX values, we need to convert them to an unsigned long.
 */
-void RFID_Read::parse()
+void RFID_Reader::parse()
 {
     uint8_t lshift = 0;
     unsigned long long val = 0;

--- a/src/rfid125kHz.h
+++ b/src/rfid125kHz.h
@@ -2,7 +2,30 @@
 RFID reader.
 Based on the "rfid_reader" library (https://github.com/travisfarmer) from Travis Farmer.
 
-Author: Lubos Ruckl
+==================================================================
+Copyright (c) 2018 Lubos Ruckl
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+==================================================================
 
 Hardware: RDM6300 or RF125-PS
 Uses 125KHz RFID tags.
@@ -13,7 +36,7 @@ Uses 125KHz RFID tags.
 
 #include "Arduino.h"
 
-class RFID_Read
+class RFID_Reader
 {
 public:
     void rfidSerial(char x);

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -535,7 +535,7 @@ function listStats() {
     document.getElementById("heap").style.width = (ajaxobj.heap * 100) / 40960 + "%";
     colorStatusbar(document.getElementById("heap"));
     document.getElementById("flash").innerHTML = ajaxobj.availsize + " Bytes";
-    document.getElementById("flash").style.width = (ajaxobj.availsize * 100) / 1044464 + "%";
+    document.getElementById("flash").style.width = (ajaxobj.availsize * 100) / (ajaxobj.availsize+ajaxobj.sketchsize) + "%";
     colorStatusbar(document.getElementById("flash"));
     document.getElementById("spiffs").innerHTML = ajaxobj.availspiffs + " Bytes";
     document.getElementById("spiffs").style.width = (ajaxobj.availspiffs * 100) / ajaxobj.spiffssize + "%";

--- a/src/wsResponses.esp
+++ b/src/wsResponses.esp
@@ -63,6 +63,7 @@ void ICACHE_FLASH_ATTR sendStatus() {
 	root["heap"] = ESP.getFreeHeap();
 	root["chipid"] = String(ESP.getChipId(), HEX);
 	root["cpu"] = ESP.getCpuFreqMHz();
+	root["sketchsize"] = ESP.getSketchSize();
 	root["availsize"] = ESP.getFreeSketchSpace();
 	root["availspiffs"] = fsinfo.totalBytes - fsinfo.usedBytes;
 	root["spiffssize"] = fsinfo.totalBytes;


### PR DESCRIPTION
+ fix available flash size for 2M (otherwise it still shows 100%)
+ adding a license agreement (MIT) to the rfid125kHz library (+ refactoring)
+ adding **Serial.begin(9600)** for RDM6300 support