### PR TITLE
PIO monitor_speed didn't match with the used one

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ extra_scripts = scripts/GENdeploy.py
 build_flags = -Wl,-Teagle.flash.4m2m.ld
 src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
 upload_speed = 921600
-monitor_speed = 115200
+monitor_speed = 9600
 
 ; official ESP-RFID board (V2)
 [env:relayboard]
@@ -41,7 +41,7 @@ build_flags = 	-Wl,-Teagle.flash.4m2m.ld
 src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
 extra_scripts = scripts/OBdeploy.py
 upload_speed = 921600
-monitor_speed = 115200
+monitor_speed = 9600
 
 ; generic firmware for debugging purposes
 [env:debug]
@@ -55,4 +55,4 @@ build_flags = 	-Wl,-Teagle.flash.4m2m.ld
 src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
 extra_scripts = scripts/DBGdeploy.py
 upload_speed = 921600
-monitor_speed = 115200
+monitor_speed = 9600


### PR DESCRIPTION
This PR fixes the inconsistency between the monitor_speed value (115200) in platformio.ini and the actually used one (9600).