### PR TITLE
remove BSSID, speed up wifi connect

### DIFF
--- a/src/config.esp
+++ b/src/config.esp
@@ -95,8 +95,8 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	autoRestartIntervalSeconds = general["restart"];
 	wifiTimeout = network["offtime"];
 	const char *bssidmac = network["bssid"];
-	byte bssid[6];
-	parseBytes(bssidmac, ':', bssid, 6, 16);
+	byte bssid[6]={0,0,0,0,0,0};
+	if (strlen(bssidmac) > 0 ) parseBytes(bssidmac, ':', bssid, 6, 16);
 	deviceHostname = strdup(general["hostnm"]);
 	WiFi.hostname(deviceHostname);
 	if (!MDNS.begin(deviceHostname))

--- a/src/wifi.esp
+++ b/src/wifi.esp
@@ -93,8 +93,9 @@ void ICACHE_FLASH_ATTR fallbacktoAPMode()
 // Try to connect Wi-Fi
 bool ICACHE_FLASH_ATTR connectSTA(const char *ssid, const char *password, byte bssid[6])
 {
+	WiFi.persistent(false);
 	WiFi.mode(WIFI_STA);
-	WiFi.begin(ssid, password, 0, bssid);
+	WiFi.begin(ssid, password);
 #ifdef DEBUG
 	Serial.print(F("[ INFO ] Trying to connect WiFi: "));
 	Serial.print(ssid);

--- a/src/wifi.esp
+++ b/src/wifi.esp
@@ -93,16 +93,38 @@ void ICACHE_FLASH_ATTR fallbacktoAPMode()
 // Try to connect Wi-Fi
 bool ICACHE_FLASH_ATTR connectSTA(const char *ssid, const char *password, byte bssid[6])
 {
-	WiFi.persistent(false);
-	WiFi.mode(WIFI_STA);
-	WiFi.begin(ssid, password);
+	bool useSSID=false;
 #ifdef DEBUG
 	Serial.print(F("[ INFO ] Trying to connect WiFi: "));
-	Serial.print(ssid);
+	Serial.println(ssid);
+	Serial.print(F("[ INFO ] WiFi BSSID: "));
 #endif
+	for (int i=0; i<6; i++) 
+	{
+#ifdef DEBUG
+		Serial.print(bssid[i]);
+		if (i < 5 ) Serial.print(F(":")); else Serial.println();
+#endif
+		if (bssid[i] != 0 ) useSSID = true;
+	}
+	if (useSSID == true)
+	{
+#ifdef DEBUG
+	Serial.println(F("[ INFO ] BSSID locked"));
+#endif
+		WiFi.mode(WIFI_STA);
+		WiFi.begin(ssid, password,0,bssid);
+	} else 
+	{
+#ifdef DEBUG
+	Serial.println(F("[ INFO ] any BSSID"));
+#endif
+		WiFi.persistent(false);
+		WiFi.mode(WIFI_STA);
+		WiFi.begin(ssid, password);
+	}
 	unsigned long now = millis();
 	uint8_t timeout = 20; // define when to time out in seconds
-	Serial.println();
 	do
 	{
 		if (WiFi.status() == WL_CONNECTED)


### PR DESCRIPTION
Tring to connect in STA mode with a fixed BSSID can be a problem if multiple Access points exist. Furthermore, leaving the connection persistent (i.e. stored in the SDK) may lead to connection delay if the stronger BSSID has changed. In this scenario the connection speed is reduced dramatically from roughly 20 seconds down to 2 or 3 seconds