### PR TITLE
ISR IRAM fix and compatibility with esp 2.2.3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,8 @@
 env_default = generic
 
 [common]
-platform = espressif8266@2.0.4
+;platform = espressif8266@2.0.4
+platform = espressif8266@2.2.3
 lib_deps =
   ArduinoJson@5.13.4
   ESPAsyncTCP
@@ -11,7 +12,8 @@ lib_deps =
   ;https://github.com/me-no-dev/ESPAsyncWebServer#e4950444c41f082c1e040aca97034c3f53c8562c
   AsyncMqttClient
   https://github.com/miguelbalboa/rfid#ea7ee3f3daafd46d0c5b8438ba41147c384a1f0d
-  https://github.com/monkeyboard/Wiegand-Protocol-Library-for-Arduino.git
+  ;https://github.com/monkeyboard/Wiegand-Protocol-Library-for-Arduino.git
+  https://github.com/beikeland/Wiegand-Protocol-Library-for-Arduino.git
   Time
   Bounce2
 
@@ -26,7 +28,8 @@ lib_deps = ${common.lib_deps}
 extra_scripts = scripts/GENdeploy.py
 build_flags = -Wl,-Teagle.flash.4m2m.ld
 src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
-upload_speed = 921600
+;https://github.com/platformio/platform-espressif8266/issues/153
+upload_speed = 460800
 monitor_speed = 9600
 board_build.flash_mode = dio
 
@@ -41,7 +44,7 @@ build_flags = 	-Wl,-Teagle.flash.4m2m.ld
 		-DOFFICIALBOARD
 src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
 extra_scripts = scripts/OBdeploy.py
-upload_speed = 921600
+upload_speed = 460800
 monitor_speed = 9600
 
 ; generic firmware for debugging purposes
@@ -55,5 +58,5 @@ build_flags = 	-Wl,-Teagle.flash.4m2m.ld
 		-DDEBUG
 src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
 extra_scripts = scripts/DBGdeploy.py
-upload_speed = 921600
+upload_speed = 460800
 monitor_speed = 9600


### PR DESCRIPTION
This fixes issues #272  and #278 

[(https://github.com/platformio/platform-espressif8266/issues/153)](https://github.com/platformio/platform-espressif8266/issues/153)

[https://github.com/beikeland/Wiegand-Protocol-Library-for-Arduino/commit/775f54ef88d54251c4f6f102a15369bf13e33bff](https://github.com/beikeland/Wiegand-Protocol-Library-for-Arduino/commit/775f54ef88d54251c4f6f102a15369bf13e33bff)
