### PR TITLE
Support for multiple relays

### DIFF
--- a/src/config.esp
+++ b/src/config.esp
@@ -127,10 +127,11 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	digitalWrite(relayPin[0], !relayType[0]);
 
 	for (int i = 1; i <numRelays ; i++){
-  		activateTime[i] = hardware["rtime"+(i+1)];
-		lockType[i]= hardware["ltype"+(i+1)];
-		relayType[i] = hardware["rtype"+(i+1)];
-		relayPin[i] = hardware["rpin"+(i+1)];
+		JsonObject &relay = hardware["relay"+(i+1)];
+ 		activateTime[i] = relay["rtime"];
+		lockType[i]= relay["ltype"];
+		relayType[i] = relay["rtype"];
+		relayPin[i] = relay["rpin"];
 		pinMode(relayPin[i], OUTPUT);
 		digitalWrite(relayPin[i], !relayType[i]);
 	}

--- a/src/config.esp
+++ b/src/config.esp
@@ -62,6 +62,14 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 			openLockButton.interval(30);
 		}
 	}
+
+	if (hardware.containsKey("numrelays"))
+	{
+		numRelays = hardware["numrelays"];
+	}
+	else numRelays=1;
+
+
 #ifdef OFFICIALBOARD
 	setupWiegandReader(5, 4);
 #endif
@@ -110,12 +118,22 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	int ntpinter = ntp["interval"];
 	timeZone = ntp["timezone"];
 	activateTime = hardware["rtime"];
-	lockType = hardware["ltype"];
-	relayType = hardware["rtype"];
+	lockType[0]= hardware["ltype"];
+	relayType[0] = hardware["rtype"];
+
 #ifndef OFFICIALBOARD
-	relayPin = hardware["rpin"];
-	pinMode(relayPin, OUTPUT);
-	digitalWrite(relayPin, !relayType);
+	relayPin[0] = hardware["rpin"];
+	pinMode(relayPin[0], OUTPUT);
+	digitalWrite(relayPin[0], !relayType[0]);
+
+	for (int i = 1; i <numRelays ; i++){
+		lockType[i]= hardware["ltype"+(i+1)];
+		relayType[i] = hardware["rtype"+(i+1)];
+		relayPin[i] = hardware["rpin"+(i+1)];
+		pinMode(relayPin[i], OUTPUT);
+		digitalWrite(relayPin[i], !relayType[i]);
+	}
+
 #endif
 	const char *ssid = network["ssid"];
 	const char *password = network["pswd"];

--- a/src/config.esp
+++ b/src/config.esp
@@ -127,7 +127,7 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	digitalWrite(relayPin[0], !relayType[0]);
 
 	for (int i = 1; i <numRelays ; i++){
-		JsonObject &relay = hardware["relay"+(i+1)];
+		JsonObject &relay = hardware["relay"+String((i+1))];
  		activateTime[i] = relay["rtime"];
 		lockType[i]= relay["ltype"];
 		relayType[i] = relay["rtype"];

--- a/src/config.esp
+++ b/src/config.esp
@@ -117,7 +117,7 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	const char *ntpserver = ntp["server"];
 	int ntpinter = ntp["interval"];
 	timeZone = ntp["timezone"];
-	activateTime = hardware["rtime"];
+	activateTime[0] = hardware["rtime"];
 	lockType[0]= hardware["ltype"];
 	relayType[0] = hardware["rtype"];
 
@@ -127,6 +127,7 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	digitalWrite(relayPin[0], !relayType[0]);
 
 	for (int i = 1; i <numRelays ; i++){
+  		activateTime[i] = hardware["rtime"+(i+1)];
 		lockType[i]= hardware["ltype"+(i+1)];
 		relayType[i] = hardware["rtype"+(i+1)];
 		relayPin[i] = hardware["rpin"+(i+1)];

--- a/src/magicnumbers.h
+++ b/src/magicnumbers.h
@@ -27,6 +27,11 @@
 
 // hardware defines
 
-#define MAX_NUM_RELAYS 4
+#ifdef OFFICIALBOARD
+    #define MAX_NUM_RELAYS 1
+#else
+    #define MAX_NUM_RELAYS 4
+#endif
+
 #define LOCKTYPE_MOMENTARY 0
 #define LOCKTYPE_CONTINUOUS 1

--- a/src/magicnumbers.h
+++ b/src/magicnumbers.h
@@ -16,9 +16,17 @@
 // user related numbers
 
 #define ACCESS_GRANTED 1
+#define ACCESS_ADMIN 99
+#define ACCCESS_DENIED 0
 
 // Reader defines
 
 #define WIEGANDTYPE_KEYPRESS 4
 #define WIEGANDTYPE_PICC26 26
 #define WIEGANDTYPE_PICC34 34
+
+// hardware defines
+
+#define MAX_NUM_RELAYS 4
+#define LOCKTYPE_MOMENTARY 0
+#define LOCKTYPE_CONTINUOUS 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,12 +41,16 @@ SOFTWARE.
 
  // #define DEBUG
 
+int numRelays=1;
+
 #ifdef OFFICIALBOARD
 
 #include <Wiegand.h>
 
 WIEGAND wg;
-int relayPin[MAX_NUM_RELAYS] = {13,13,13,13};
+int relayPin[MAX_NUM_RELAYS] = {13};
+bool activateRelay [MAX_NUM_RELAYS]= {false};
+bool deactivateRelay [MAX_NUM_RELAYS]= {false};
 
 #endif
 
@@ -67,16 +71,16 @@ int readertype;
 
 // relay specific variables
 
-int numRelays=1;
 int relayPin[MAX_NUM_RELAYS];
-int lockType[MAX_NUM_RELAYS];
-int relayType[MAX_NUM_RELAYS];
 bool activateRelay [MAX_NUM_RELAYS]= {false,false,false,false};
 bool deactivateRelay [MAX_NUM_RELAYS]= {false,false,false,false};
-unsigned long activateTime[MAX_NUM_RELAYS];
-
 
 #endif
+
+int lockType[MAX_NUM_RELAYS];
+int relayType[MAX_NUM_RELAYS];
+unsigned long activateTime[MAX_NUM_RELAYS];
+
 
 // these are from vendors
 #include "webh/glyphicons-halflings-regular.woff.gz.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,8 @@ int lockType[MAX_NUM_RELAYS];
 int relayType[MAX_NUM_RELAYS];
 bool activateRelay [MAX_NUM_RELAYS]= {false,false,false,false};
 bool deactivateRelay [MAX_NUM_RELAYS]= {false,false,false,false};
+unsigned long activateTime[MAX_NUM_RELAYS];
+
 
 #endif
 
@@ -146,7 +148,6 @@ char *muser = NULL;
 char *mpas = NULL;
 int mport;
 
-unsigned long activateTime;
 int timeZone;
 
 unsigned long nextbeat = 0;
@@ -309,7 +310,7 @@ void ICACHE_RAM_ATTR loop()
 			activateRelay[currentRelay] = false;
 		}
 	  }
-	  else if (lockType[currentRelay] == 0)	// momentary relay mode
+	  else if (lockType[currentRelay] == LOCKTYPE_MOMENTARY)	// momentary relay mode
 	  {
 		if (activateRelay[currentRelay])
 		{
@@ -323,7 +324,7 @@ void ICACHE_RAM_ATTR loop()
 			activateRelay[currentRelay] = false;
 			deactivateRelay[currentRelay] = true;
 		}
-		else if ((currentMillis - previousMillis >= activateTime) && (deactivateRelay[currentRelay]))
+		else if ((currentMillis - previousMillis >= activateTime[currentRelay]) && (deactivateRelay[currentRelay]))
 		{
 #ifdef DEBUG
 			Serial.println(currentMillis);

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -238,7 +238,7 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
 		#ifdef DEBUG
 			Serial.println("[ INFO ] Door open");
 		#endif
-		activateRelay = true;
+		activateRelay[0] = true;
 		previousMillis = millis();
 		return;
 	}

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -242,7 +242,6 @@ void ICACHE_FLASH_ATTR rfidloop()
 		return;
 	}
 #endif
-	int AccType = 0;
 	String filename = "/P/";
 	filename += uid;
 	File f = SPIFFS.open(filename, "r");
@@ -255,8 +254,18 @@ void ICACHE_FLASH_ATTR rfidloop()
 		JsonObject &json = jsonBuffer.parseObject(buf.get());
 		if (json.success())
 		{
+
+		  for (int currentRelay = 0; currentRelay < numRelays ; currentRelay++){
+
+			int AccType = ACCCESS_DENIED;
+  
+
 			String username = json["user"];
-			AccType = json["acctype"];
+			if (currentRelay == 0)
+			   AccType = json["acctype"];
+			else
+			   AccType = json["acctype"+(currentRelay+1)];
+			
 #ifdef DEBUG
 			Serial.println(" = known PICC");
 			Serial.print("[ INFO ] User Name: ");
@@ -265,17 +274,17 @@ void ICACHE_FLASH_ATTR rfidloop()
 			else
 				Serial.print(username);
 #endif
-			if (AccType == 1)
+			if (AccType == ACCESS_GRANTED)
 			{
 				unsigned long validL = json["validuntil"];
 				unsigned long nowL = now();
 
 				if (validL > nowL)
 				{
-					activateRelay = true;
+					activateRelay[currentRelay] = true;
 					ws.textAll("{\"command\":\"giveAccess\"}");
 #ifdef DEBUG
-					Serial.println(" have access");
+					Serial.printf(" has access relay %d\n",currentRelay);
 #endif
 					if (mqttenabled == 1)
 					{
@@ -292,16 +301,15 @@ void ICACHE_FLASH_ATTR rfidloop()
 					{
 						mqtt_publish_access(now(), "true", "Expired", username, uid);
 					}
-					AccType = 2;
 				}
 			}
-			else if (AccType == 99)
+			else if (AccType == ACCESS_ADMIN)
 			{
 				doEnableWifi = true;
-				activateRelay = true;
+				activateRelay[currentRelay] = true;
 				ws.textAll("{\"command\":\"giveAccess\"}");
 #ifdef DEBUG
-				Serial.println(" have admin access, enable wifi");
+				Serial.println(" has admin access, enable wifi");
 #endif
 				if (mqttenabled == 1)
 				{
@@ -334,6 +342,7 @@ void ICACHE_FLASH_ATTR rfidloop()
 				root.printTo((char *)buffer->get(), len + 1);
 				ws.textAll(buffer);
 			}
+		  }
 		}
 		else
 		{

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -264,7 +264,7 @@ void ICACHE_FLASH_ATTR rfidloop()
 			if (currentRelay == 0)
 			   AccType = json["acctype"];
 			else
-			   AccType = json["acctype"+(currentRelay+1)];
+			   AccType = json["acctype"+String(currentRelay+1)];
 			
 #ifdef DEBUG
 			Serial.println(" = known PICC");

--- a/src/websocket.esp
+++ b/src/websocket.esp
@@ -115,6 +115,7 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		previousMillis = millis();
 		ws.textAll("{\"command\":\"giveAccess\"}");
 	}
+#ifndef OFFICIALBOARD	
 	else if (strcmp(command, "testrelay2") == 0)
 	{
 		activateRelay[1] = true;
@@ -133,6 +134,7 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		previousMillis = millis();
 		ws.textAll("{\"command\":\"giveAccess\"}");
 	}
+#endif
 	else if (strcmp(command, "scan") == 0)
 	{
 		WiFi.scanNetworksAsync(printScanResult, true);

--- a/src/websocket.esp
+++ b/src/websocket.esp
@@ -109,9 +109,27 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		f.close();
 		ws.textAll("{\"command\":\"result\",\"resultof\":\"userfile\",\"result\": true}");
 	}
-	else if (strcmp(command, "testrelay") == 0)
+	else if (strcmp(command, "testrelay1") == 0)
 	{
-		activateRelay = true;
+		activateRelay[0] = true;
+		previousMillis = millis();
+		ws.textAll("{\"command\":\"giveAccess\"}");
+	}
+	else if (strcmp(command, "testrelay2") == 0)
+	{
+		activateRelay[1] = true;
+		previousMillis = millis();
+		ws.textAll("{\"command\":\"giveAccess\"}");
+	}
+	else if (strcmp(command, "testrelay3") == 0)
+	{
+		activateRelay[2] = true;
+		previousMillis = millis();
+		ws.textAll("{\"command\":\"giveAccess\"}");
+	}
+	else if (strcmp(command, "testrelay4") == 0)
+	{
+		activateRelay[3] = true;
 		previousMillis = millis();
 		ws.textAll("{\"command\":\"giveAccess\"}");
 	}

--- a/src/websocket.esp
+++ b/src/websocket.esp
@@ -96,6 +96,12 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 	}
 	else if (strcmp(command, "userfile") == 0)
 	{
+#ifdef DEBUG
+		Serial.println(F("[ DEBUG ] userfile received"));
+		String st = String();
+		root.printTo(st);
+		Serial.println(st);
+#endif
 		const char *uid = root["uid"];
 		String filename = "/P/";
 		filename += uid;
@@ -105,6 +111,9 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		{
 			//f.print(msg);
 			root.printTo(f);
+#ifdef DEBUG
+		Serial.println(F("[ DEBUG ] userfile saved"));
+#endif
 		}
 		f.close();
 		ws.textAll("{\"command\":\"result\",\"resultof\":\"userfile\",\"result\": true}");

--- a/src/websrc/esprfid.htm
+++ b/src/websrc/esprfid.htm
@@ -832,7 +832,7 @@
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
                     <h4 class="modal-title" id="editor-title">Add User</h4>
                 </div>
-                <div class="modal-body">
+                <div id=usermodalbody class="modal-body">
                     <input type="number" id="id" name="id" class="hidden" />
                     <div class="form-group">
                         <label for="picctype" class="col-sm-3 control-label">PICC Type</label>

--- a/src/websrc/esprfid.htm
+++ b/src/websrc/esprfid.htm
@@ -302,7 +302,7 @@
       <div class="row form-group">
         <label class="col-xs-3">Lock Type<i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="Use momentary method for door lock counterparts, and the continuous one for electromagnetic locks."></i></label>
         <span class="col-xs-9 col-md-5">
-            <select class="form-control input-sm" id="lockType" onchange="handleLock();">
+            <select class="form-control input-sm" id="lockType" onchange="handleLock(1);">
                 <option selected="selected" value="0">Momentary</option>
                 <option value="1">Continuous</option>
             </select>

--- a/src/websrc/esprfid.htm
+++ b/src/websrc/esprfid.htm
@@ -296,7 +296,7 @@
                 </select>
               </span>
         <span class="col-xs-3">
-            <button id="testb" type="button" class="btn btn-primary btn-xs" onclick="testRelay()">Test</button><i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="left" data-content="Test previous relay setting. Keep in mind that this is actually triggers the relay."></i>
+            <button id="testb" type="button" class="btn btn-primary btn-xs" onclick="testRelay(1)">Test</button><i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="left" data-content="Test previous relay setting. Keep in mind that this is actually triggers the relay."></i>
         </span>
       </div>
       <div class="row form-group">

--- a/src/websrc/esprfid.htm
+++ b/src/websrc/esprfid.htm
@@ -253,6 +253,24 @@
     </div>
     <hr>
     <div class="row form-group">
+        <label class="col-xs-3">Number of relays<i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="Choose how many relays your board has"></i></label>
+        <span class="col-xs-6 col-md-5">
+                <select class="form-control input-sm" id="numrlys">
+                    <option selected="selected" value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                </select>
+              </span>
+        <span class="col-xs-3">
+            <button id="changenumrly" type="button" class="btn btn-primary btn-xs" onclick="changeRelayNumber()">update</button><i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="left" data-content="Click here to display the right number of forms"></i>
+        </span>
+    </div>
+
+    <div id=relayformparent >
+     <div id=relayform>
+        <div id=relaytitle>Relay 1 Settings</div><br><br>
+        <div class="row form-group">
         <label class="col-xs-3">Relay Type<i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="Depending on your electrical setup, you can choose the relay type"></i></label>
         <span class="col-xs-9 col-md-5">
             <select class="form-control input-sm" id="typerly">
@@ -260,8 +278,8 @@
               <option value="0">Active Low</option>
             </select>
             </span>
-    </div>
-    <div class="row form-group">
+      </div>
+      <div class="row form-group">
         <label class="col-xs-3">Relay Pin<i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="Choose which ESP port is connected to your relay"></i></label>
         <span class="col-xs-6 col-md-5">
                 <select class="form-control input-sm" id="gpiorly">
@@ -280,8 +298,8 @@
         <span class="col-xs-3">
             <button id="testb" type="button" class="btn btn-primary btn-xs" onclick="testRelay()">Test</button><i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="left" data-content="Test previous relay setting. Keep in mind that this is actually triggers the relay."></i>
         </span>
-    </div>
-    <div class="row form-group">
+      </div>
+      <div class="row form-group">
         <label class="col-xs-3">Lock Type<i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="Use momentary method for door lock counterparts, and the continuous one for electromagnetic locks."></i></label>
         <span class="col-xs-9 col-md-5">
             <select class="form-control input-sm" id="lockType" onchange="handleLock();">
@@ -289,12 +307,14 @@
                 <option value="1">Continuous</option>
             </select>
         </span>
-    </div>
-    <div class="row form-group" id="activateTimeForm">
+      </div>
+      <div class="row form-group" id="activateTimeForm">
         <label class="col-xs-3">Activate Time<i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="right" data-content="Relay Toggle time in Microseconds, usually 300ms is enough for the most electric door locks"></i></label>
         <span class="col-xs-9 col-md-5">
             <input class="form-control input-sm" value="300" placeholder="in Microsecond" id="delay" type="text" name="hightime">
         </span>
+      </div>
+     </div> 
     </div>
     <div class="row form-group">
         <br>
@@ -832,7 +852,7 @@
                             <input type="text" class="form-control" id="username" name="username" placeholder="User Name or Label" required>
                         </div>
                     </div>
-                    <div class="form-group required">
+                    <div id=useracctype class="form-group required">
                         <label for="acctype" class="col-sm-3 control-label">Access Type</label>
                         <div class="col-sm-9">
                             <select class="form-control" id="acctype" required>

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -1139,6 +1139,7 @@ function initLatestLogTable() {
 }
 
 function initUserTable() {
+  updateUserModalForm();
   jQuery(function($) {
     var $modal = $("#editor-modal"),
       $editor = $("#editor"),
@@ -1309,6 +1310,9 @@ function initUserTable() {
       datatosend.uid = $editor.find("#uid").val();
       datatosend.user = $editor.find("#username").val();
       datatosend.acctype = parseInt($editor.find("#acctype").val());
+      datatosend.acctype2 = parseInt($editor.find("#acctype2").val());
+      datatosend.acctype3 = parseInt($editor.find("#acctype3").val());
+      datatosend.acctype4 = parseInt($editor.find("#acctype4").val());
       var validuntil = $editor.find("#validuntil").val();
       var vuepoch = (new Date(validuntil).getTime() / 1000);
       datatosend.validuntil = vuepoch;
@@ -1407,6 +1411,7 @@ function socketMessageListener(evt) {
         config = obj;
         if (!('wifipin' in config.hardware)) config.hardware.wifipin = 255;
         if (!('doorstatpin' in config.hardware)) config.hardware.doorstatpin = 255;
+        if ('numrelays' in config.hardware) numRelays = config.hardware["numrelays"]; else config.hardware["numrelays"] = numRelays;
         break;
       default:
         break;
@@ -1601,8 +1606,8 @@ function updateRelayForm(){
         str=str.replace ("activateTimeForm","activateTimeForm"+i);
         cloneObj.innerHTML=str.replace ("delay","delay" +i);
         relayparent[0].appendChild(relayFormClone[0]);
-        handleLock(i);
       }
+      handleLock(i);
     } else {
       var removeRelayForm = document.getElementById("relayform" + i);
       if (removeRelayForm)

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -629,8 +629,8 @@ function builddata(obj) {
   data = data.concat(obj.list);
 }
 
-function testRelay() {
-  websock.send("{\"command\":\"testrelay\"}");
+function testRelay(xnum) {
+  websock.send("{\"command\":\"testrelay" + xnum + "\"}");
 }
 
 function colorStatusbar(ref) {
@@ -1584,6 +1584,7 @@ function updateRelayForm(){
         str=str.replace ("lockType","lockType" +i);
         str=str.replace ("typerly","typerly" +i);
         str=str.replace ("handleLock(1)","handleLock(" +i+")");
+        str=str.replace ("testRelay(1)","testRelay(" +i+")");
         str=str.replace ("activateTimeForm","activateTimeForm"+i);
         cloneObj.innerHTML=str.replace ("delay","delay" +i);
         relayparent[0].appendChild(relayFormClone[0]);

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -8,6 +8,9 @@ var data = [];
 var ajaxobj;
 var isOfficialBoard = false;
 
+var maxNumRelays=4;
+var numRelays=1;
+
 var theCurrentLogFile ="";
 
 var config = {
@@ -1442,6 +1445,41 @@ function clearlatest() {
   if (confirm('Deleting the Access log file can not be undone - delete ?')) {
     websock.send("{\"command\":\"clearlatest\"}");
     $("#latestlog").click();
+  }
+}
+
+function changeRelayNumber(){
+  numRelays = $("#numrlys :selected").val();
+  updateRelayForm();
+}
+
+function updateRelayForm(){
+  //alert (numRelays);
+  var i;
+  for (i=2; i<= maxNumRelays; i++)
+  {
+    var relayForm = $("#relayform");
+    var relayparent= $("#relayformparent");
+    if (i<= numRelays) 
+    {
+      var existingRelayForm = document.getElementById("relayform" + i);
+      if (!(existingRelayForm))
+      {
+        var relayFormClone = relayForm.clone(true);
+        relayFormClone.attr('id', 'relayform' + i);
+        var cloneTitle = relayFormClone[0].children[0];
+        cloneTitle.innerText = 'Relay ' + i + " settings";
+        //cloneTitle.innerHTML = 'relayform' + i;
+        // add class duplicate
+        relayparent[0].appendChild(relayFormClone[0]);
+      }
+    } else {
+      var removeRelayForm = document.getElementById("relayform" + i);
+      if (removeRelayForm)
+      {
+        relayparent[0].removeChild(removeRelayForm);
+      }
+    }
   }
 }
 

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -9,7 +9,7 @@ var ajaxobj;
 var isOfficialBoard = false;
 
 var maxNumRelays=4;
-var numRelays=1;
+var numRelays=3;
 
 var theCurrentLogFile ="";
 
@@ -160,6 +160,14 @@ function listhardware() {
     document.getElementById("gpioss").value = config.hardware.sspin;
     document.getElementById("gain").value = config.hardware.rfidgain;
     document.getElementById("gpiorly").value = config.hardware.rpin;
+    document.getElementById("numrlys").value = numRelays;
+    updateRelayForm();
+
+    for (var i = 2; i<=numRelays; i++)
+    {
+      // read the other relays 
+      // downstream compat - add node if not there
+    }
   }
   handleReader();
   handleLock();
@@ -1132,8 +1140,56 @@ function initUserTable() {
           },
           {
             "name": "acctype",
-            "title": "Access Type",
+            "title": "Access Rl1",
             "breakpoints": "xs",
+            "parser": function(value) {
+              if (value === 1) {
+                return "Always";
+              } else if (value === 99) {
+                return "Admin";
+              } else if (value === 0) {
+                return "Disabled";
+              }
+              return value;
+            },
+          },
+          {
+            "name": "acctype2",
+            "title": "Access Rl2",
+            "breakpoints": "xs",
+            "visible": false,
+            "parser": function(value) {
+              if (value === 1) {
+                return "Always";
+              } else if (value === 99) {
+                return "Admin";
+              } else if (value === 0) {
+                return "Disabled";
+              }
+              return value;
+            },
+          },
+          {
+            "name": "acctype3",
+            "title": "Access Rl3",
+            "breakpoints": "xs",
+            "visible": false,
+            "parser": function(value) {
+              if (value === 1) {
+                return "Always";
+              } else if (value === 99) {
+                return "Admin";
+              } else if (value === 0) {
+                return "Disabled";
+              }
+              return value;
+            },
+          },
+          {
+            "name": "acctype4",
+            "title": "Access Rl4",
+            "breakpoints": "xs",
+            "visible": false,
             "parser": function(value) {
               if (value === 1) {
                 return "Always";
@@ -1234,6 +1290,25 @@ function initUserTable() {
       $modal.modal("hide");
     });
   });
+
+  ft=FooTable.get('#usertable');
+  
+
+  for (var i=2; i<= maxNumRelays; i++)
+  {
+    var relayForm = $("#relayform");
+    var relayparent= $("#relayformparent");
+    if (i<= numRelays) 
+    {
+      //FooTable.get('#usertable').draw();
+      ft.columns.get("acctype"+i).visible=true;
+    }
+    else
+    {
+      ft.columns.get("acctype"+i).visible=false;
+    }  
+    ft.draw();
+  }
 }
 
 function restartESP() {

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -1244,16 +1244,23 @@ function initUserTable() {
           editRow: function(row) {
             var acctypefinder;
             var values = row.val();
-            if (values.acctype === "Always") {
-              acctypefinder = 1;
-            } else if (values.acctype === "Admin") {
-              acctypefinder = 99;
-            } else if (values.acctype === "Disabled") {
-              acctypefinder = 0;
+
+            function giveAccType(xnum){
+              var xval;
+              if (xnum===1) xval = values.acctype;
+              if (xnum===2) xval = values.acctype2;
+              if (xnum===3) xval = values.acctype3;
+              if (xnum===4) xval = values.acctype4;
+              if (xval === "Always")  return 1;
+              if (xval === "Admin")  return 99;
+              if (xval === "Disabled") return 0;
             }
             $editor.find("#uid").val(values.uid);
             $editor.find("#username").val(values.username);
-            $editor.find("#acctype").val(acctypefinder);
+            $editor.find("#acctype").val(giveAccType(1));
+            $editor.find("#acctype2").val(giveAccType(2));
+            $editor.find("#acctype3").val(giveAccType(3));
+            $editor.find("#acctype4").val(giveAccType(4));
             $editor.find("#validuntil").val(values.validuntil);
             $modal.data("row", row);
             $editorTitle.text("Edit User # " + values.username);
@@ -1284,6 +1291,9 @@ function initUserTable() {
           uid: $editor.find("#uid").val(),
           username: $editor.find("#username").val(),
           acctype: parseInt($editor.find("#acctype").val()),
+          acctype2: parseInt($editor.find("#acctype2").val()),
+          acctype3: parseInt($editor.find("#acctype3").val()),
+          acctype4: parseInt($editor.find("#acctype4").val()),
           validuntil: (new Date($editor.find("#validuntil").val()).getTime() / 1000)
         };
       if (row instanceof window.FooTable.Row) {

--- a/src/websrc/js/esprfid.js
+++ b/src/websrc/js/esprfid.js
@@ -164,6 +164,8 @@ function listhardware() {
     document.getElementById("gpiorly").value = config.hardware.rpin;
     document.getElementById("numrlys").value = numRelays;
     updateRelayForm();
+    updateUserModalForm();
+
 
     for (var i = 2; i<=numRelays; i++)
     {
@@ -1545,6 +1547,7 @@ function changeRelayNumber(){
   // add the missing form elements
 
   updateRelayForm();
+  updateUserModalForm();
 }
 
 function updateRelayForm(){
@@ -1595,6 +1598,37 @@ function updateRelayForm(){
       if (removeRelayForm)
       {
         relayparent[0].removeChild(removeRelayForm);
+      }
+    }
+  }
+}
+
+function updateUserModalForm(){
+  var i;
+  for (i=2; i<= maxNumRelays; i++)
+  {
+    var accTypeForm = $("#useracctype");
+    var accParent= $("#usermodalbody");
+    if (i<= numRelays) 
+    {
+      var existingaccTypeForm = document.getElementById("useracctype" + i);
+      if (!(existingaccTypeForm))
+      {
+        var accTypeFormClone = accTypeForm.clone(true);
+        var cloneObj = accTypeFormClone[0];
+        accTypeFormClone.attr('id', 'useracctype' + i);
+
+        var str = cloneObj.innerHTML;
+        str=str.replace(/acctype/g,"acctype"+i);
+        str=str.replace("Access Type","Access Relay "+i);
+        cloneObj.innerHTML=str;
+        accParent[0].appendChild(cloneObj);
+      }
+    } else {
+      var removeAccForm = document.getElementById("useracctype" + i);
+      if (removeAccForm)
+      {
+        accParent[0].removeChild(removeAccForm);
       }
     }
   }

--- a/src/wsResponses.esp
+++ b/src/wsResponses.esp
@@ -22,10 +22,18 @@ void ICACHE_FLASH_ATTR sendUserList(int page, AsyncWebSocketClient *client) {
 			JsonObject &json = jsonBuffer2.parseObject(buf.get());
 			if (json.success()) {
 				String username = json["user"];
-				int AccType = json["acctype"];
+				for (int x=1; x<=MAX_NUM_RELAYS; x++)
+				{
+					String theKey=String();
+					if (x==1) theKey = "acctype"; else theKey = "acctype" + String(x);
+					int AccType = json[theKey];
+#ifdef DEBUG
+ // Serial.printf ("[ DEBUG ] User uid %s Acctype %d %d key %s\n", uid.c_str()  , x ,AccType,theKey.c_str());
+#endif
+					item[theKey] = AccType;
+				}
 				unsigned long validuntil = json["validuntil"];
 				item["username"] = username;
-				item["acctype"] = AccType;
 				item["validuntil"] = validuntil;
 			}
 		}


### PR DESCRIPTION
Allow a configurable number of relays. 

**Use case**

I have two garage doors but only one RFID reader. Some codes should open the right door, some the left door and maybe some should open both doors.

Possible use case might be as well switching on a light or signal etc.

**Interface and downstream compatibility**

The number of relays can be configured in the UI, the maximum number of relays is currently hard coded to 4 but can easily be changed. For the official board the number is hard coded to 1.

The settings names for the first relay have not been changed in order to provide downstream compatibility to previous releases. For each additional relay a node is appended to the hardware node

The user forms and files have been amended in order to reflect access rights to a specific relay

**Known issues**:

- on User access, multiple entries are created in the access log - one for each relay. At this point the log does not contain information of which relay has been accepted and which has been denied
- If a user has access to only some relays, a denied message will be entered in the event log for each additional relay
- MQTT open door command only opens the first relay
