### PR TITLE
Fix for #354 (platform setting breaks buildability)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -2,8 +2,7 @@
 default_envs = generic
 
 [common]
-;platform = espressif8266@2.0.4
-platform = espressif8266@2.2.3
+platform = espressif8266@2.3.2
 lib_deps =
   ArduinoJson@5.13.4
   ESPAsyncTCP


### PR DESCRIPTION
As described in #354, the actual dev branch is not builadable due to incompatibilities with the settings of platform in platformio.ini.
This pull request changes the setting of platform to the latest version 
`platform = espressif8266@2.3.2 `

I verfied the change by building successfully via "platformio run" on command line.