### PR TITLE
Corrected text for relay test info bubble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ typings/
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/*
+.DS_Store

--- a/src/websrc/esprfid.htm
+++ b/src/websrc/esprfid.htm
@@ -246,7 +246,7 @@
                 </select>
               </span>
         <span class="col-xs-3">
-            <button id="testb" type="button" class="btn btn-primary btn-xs" onclick="testRelay()">Test</button><i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="left" data-content="Test previous relay setting. Keep in mind that this is actually triggers the relay."></i>
+            <button id="testb" type="button" class="btn btn-primary btn-xs" onclick="testRelay()">Test</button><i style="margin-left: 10px;" class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="popover" data-trigger="hover" data-placement="left" data-content="Test previous relay setting. Keep in mind that this will actually trigger the relay."></i>
         </span>
     </div>
     <div class="row form-group">


### PR DESCRIPTION
Smoothed over the English text in the info bubble for Test Relay.
Added Mac .DS_Store to .gitignore