### PR TITLE
Refactor Wiegand reading function

### DIFF
--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -1,7 +1,61 @@
+String uid = "";
+String type = "";
+
+void wiegandRead()
+{
+	// if we get 26 or 34 bit burst then we have a scanned PICC
+	if (wg.getWiegandType() == WIEGANDTYPE_PICC26 || wg.getWiegandType() == WIEGANDTYPE_PICC34)
+	{
+#ifdef DEBUG
+		Serial.print(F("[ INFO ] PICC's UID: "));
+		Serial.println(wg.getCode());
+#endif
+		uid = String(wg.getCode(), DEC);
+		type = String(wg.getWiegandType(), DEC);
+		cooldown = millis() + 2000;
+	}
+	// if we get a 4 bit burst then a key has been pressed
+	// add the key to the current input and reset the Waiting time
+	// for the next key unless * or # have been pressed
+	// we do not require * as the first character because some
+	// readers use this as special admin code and would hence require *#PIN#
+	if (wg.getWiegandType() == WIEGANDTYPE_KEYPRESS /*  && keyTimer > 0 */ && String(wg.getCode(), HEX) != "d" && String(wg.getCode(), HEX) != "1b")
+	{
+#ifdef DEBUG
+		Serial.println("Keycode captured. . .");
+#endif
+		currentInput = currentInput + String(wg.getCode());
+		keyTimer = millis();
+	}
+	// When # is pressed stop keytimer to capture code
+	if (wg.getWiegandType() == WIEGANDTYPE_KEYPRESS && keyTimer > 0 && String(wg.getCode(), HEX) == "d")
+	{
+#ifdef DEBUG
+		Serial.println("Stop capture keycode . . .");
+		Serial.print(F("[ INFO ] PICC's UID: "));
+		Serial.println(currentInput);
+#endif
+		uid = currentInput;
+		type = "PIN";
+		currentInput = "";
+		keyTimer = 0;
+		cooldown = millis() + COOLDOWN_MILIS;
+	}
+}
+
 void ICACHE_FLASH_ATTR rfidloop()
 {
-	String uid = "";
-	String type = "";
+#ifdef OFFICIALBOARD
+	if (wg.available())
+	{
+		wiegandRead();
+	}
+	else
+	{
+		delay(50);
+		return;
+	}
+#endif
 #ifndef OFFICIALBOARD
 	if (readertype == READER_MFRC522)
 	{
@@ -37,47 +91,11 @@ void ICACHE_FLASH_ATTR rfidloop()
 	{
 		if (wg.available())
 		{
-			// if we get 26 or 34 bit burst then we have a scanned PICC
-			if (wg.getWiegandType() == WIEGANDTYPE_PICC26 || wg.getWiegandType() == WIEGANDTYPE_PICC34)
-			{
-#ifdef DEBUG
-				Serial.print(F("[ INFO ] PICC's UID: "));
-				Serial.println(wg.getCode());
-#endif
-				uid = String(wg.getCode(), DEC);
-				type = String(wg.getWiegandType(), DEC);
-				cooldown = millis() + 2000;
-			}
-			// if we get a 4 bit burst then a key has been pressed
-			// add the key to the current input and reset the Waiting time
-			// for the next key unless * or # have been pressed
-			// we do not require * as the first character because some
-			// readers use this as special admin code and would hence require *#PIN#
-			if (wg.getWiegandType() == WIEGANDTYPE_KEYPRESS /*  && keyTimer > 0 */ && String(wg.getCode(), HEX) != "d" && String(wg.getCode(), HEX) != "1b")
-			{
-#ifdef DEBUG
-				Serial.println("Keycode captured. . .");
-#endif
-				currentInput = currentInput + String(wg.getCode());
-				keyTimer = millis();
-			}
-			// When # is pressed stop keytimer to capture code
-			if (wg.getWiegandType() == WIEGANDTYPE_KEYPRESS && keyTimer > 0 && String(wg.getCode(), HEX) == "d")
-			{
-#ifdef DEBUG
-				Serial.println("Stop capture keycode . . .");
-				Serial.print(F("[ INFO ] PICC's UID: "));
-				Serial.println(currentInput);
-#endif
-				uid = currentInput;
-				type = "PIN";
-				currentInput = "";
-				keyTimer = 0;
-				cooldown = millis() + COOLDOWN_MILIS;
-			}
+			wiegandRead();
 		}
 		else
 		{
+			delay(50);
 			return;
 		}
 	}
@@ -220,59 +238,10 @@ void ICACHE_FLASH_ATTR rfidloop()
 	if (keyTimer > 0) // we are still waiting for keycode to build up
 	{
 #ifdef DEBUG
-		Serial.println("[ INFO ] still waiting for keypress");
+		Serial.println("[ INFO ] still waiting for keypress!!");
 #endif
-		//return;
-	}
-#ifdef OFFICIALBOARD
-	if (wg.available())
-	{
-
-		// if we get 26 or 34 bit burst then we have a scanned PICC
-		if ((wg.getWiegandType() == WIEGANDTYPE_PICC26) || (wg.getWiegandType() == WIEGANDTYPE_PICC34))
-		{
-#ifdef DEBUG
-			Serial.print(F("[ INFO ] PICC's UID: "));
-			Serial.println(wg.getCode());
-#endif
-			uid = String(wg.getCode(), DEC);
-			type = String(wg.getWiegandType(), DEC);
-			cooldown = millis() + 2000;
-		}
-		// if we get a 4 bit burst then a key has been pressed
-		// add the key to the current input and reset the Waiting time
-		// for the next key unless * or # have been pressed
-		// we do not require * as the first character because some
-		// readers use this as special admin code and would hence require *#PIN#
-		if ((wg.getWiegandType() == WIEGANDTYPE_KEYPRESS) /*  && keyTimer > 0 */ && (String(wg.getCode(), HEX) != "d") && (String(wg.getCode(), HEX) != "1b"))
-		{
-#ifdef DEBUG
-			Serial.println("Keycode captured. . .");
-#endif
-			currentInput = currentInput + String(wg.getCode());
-			keyTimer = millis();
-		}
-		// When # is pressed stop keytimer to capture code
-		if ((wg.getWiegandType() == WIEGANDTYPE_KEYPRESS) && (keyTimer > 0) && (String(wg.getCode(), HEX) == "d"))
-		{
-#ifdef DEBUG
-			Serial.println("Stop capture keycode . . .");
-			Serial.print(F("[ INFO ] PICC's UID: "));
-			Serial.println(currentInput);
-#endif
-			uid = currentInput;
-			type = "PIN";
-			currentInput = "";
-			keyTimer = 0;
-			cooldown = millis() + COOLDOWN_MILIS;
-		}
-	}
-	else
-	{
-		delay(50);
 		return;
 	}
-#endif
 	String filename = "/P/";
 	filename += uid;
 	File f = SPIFFS.open(filename, "r");


### PR DESCRIPTION
I'm trying to add some functionality to the Wiegand reader and I've noticed that the code is duplicated between the official board and the others.

In extracting the code in the function I've minimized the changes.

While doing so I've also found a bug when using the keypad as a return statement was commented out, for every keypress the function was going ahead and testing if the user was in the memory, even if the uid wasn't filled in.

I don't have yet an official board to test (soon though!), but the code is building properly.