### PR TITLE
Fix receiving MQTT messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,6 +174,8 @@ bool mqttEvents = false;	  // Sends events over MQTT disables SPIFFS file loggin
 
 bool mqttHA = false; // Sends events over simple MQTT topics and AutoDiscovery
 
+char mqttBuffer[1460];
+
 #include "log.esp"
 #include "mqtt.esp"
 #include "helpers.esp"

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -375,23 +375,30 @@ void DeleteUserID(const char *uid)
 
 void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)
 {
-	char jjson[total + 1];
-	memcpy(jjson, payload, total);
-	jjson[total + 1] = '\0';
-	String espIp = WiFi.localIP().toString();
-	Serial.println(espIp);
+	size_t n = 0;
+	size_t i = index;
+	while(n < len) {
+		mqttBuffer[i] = payload[n];
+		n++;
+		i++;
+	}
+	if(index + len == total) {
+		mqttBuffer[i + 1] = '\0';
+	} else {
+		return;
+	}
 	StaticJsonBuffer<255> jsonBuffer;
 #ifdef DEBUG
 	Serial.print("[ INFO ] JSON msg :");
-	Serial.println(jjson);
+	Serial.println(mqttBuffer);
 #endif
 
-	JsonObject &root = jsonBuffer.parseObject(jjson);
+	JsonObject &root = jsonBuffer.parseObject(mqttBuffer);
 	if (!root.success())
 	{
 #ifdef DEBUG
 		Serial.print("[ INFO ] Failed parse MQTT message :");
-		Serial.println(jjson);
+		Serial.println(mqttBuffer);
 #endif
 		return;
 	}
@@ -403,7 +410,7 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 		if (root.containsKey("doorip"))
 		{
 			const char *ipadr = root["doorip"];
-
+			String espIp = WiFi.localIP().toString();
 			if (!((strcmp(ipadr, espIp.c_str()) == 0) && (ipadr != NULL)))
 			{
 #ifdef DEBUG


### PR DESCRIPTION
onMqttMessage can be called with part of a message, not the entire one.
This happens frequently in case of a lot of subsequent messages sent.

This commit reads messages, up to 1460 bytes, even if sent across multiple
calls to onMqttMessage.

[More documentation on how it works here](https://github.com/marvinroger/async-mqtt-client/blob/develop/docs/3.-Memory-management.md#incoming-messages)