### PR TITLE
Upgrade to ArduinoJSON v6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ default_envs = generic
 [common]
 platform = espressif8266@2.3.2
 lib_deps =
-  ArduinoJson@5.13.4
+  ArduinoJson@6.19.1
   ESPAsyncTCP
   ESPAsyncUDP
   ESP Async WebServer

--- a/src/config.esp
+++ b/src/config.esp
@@ -11,9 +11,9 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	size_t size = configFile.size();
 	std::unique_ptr<char[]> buf(new char[size]);
 	configFile.readBytes(buf.get(), size);
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &json = jsonBuffer.parseObject(buf.get());
-	if (!json.success())
+	DynamicJsonDocument json(4096);
+	auto error = deserializeJson(json, buf.get());
+	if (error)
 	{
 #ifdef DEBUG
 		Serial.println(F("[ WARN ] Failed to parse config file"));
@@ -22,14 +22,14 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 	}
 #ifdef DEBUG
 	Serial.println(F("[ INFO ] Config file found"));
-	json.prettyPrintTo(Serial);
+	serializeJsonPretty(json, Serial);
 	Serial.println();
 #endif
-	JsonObject &network = json["network"];
-	JsonObject &hardware = json["hardware"];
-	JsonObject &general = json["general"];
-	JsonObject &mqtt = json["mqtt"];
-	JsonObject &ntp = json["ntp"];
+	JsonObject network = json["network"];
+	JsonObject hardware = json["hardware"];
+	JsonObject general = json["general"];
+	JsonObject mqtt = json["mqtt"];
+	JsonObject ntp = json["ntp"];
 #ifdef DEBUG
 	Serial.println(F("[ INFO ] Trying to setup RFID Hardware"));
 #endif
@@ -162,7 +162,7 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 
 	for (int i = 1; i < numRelays; i++)
 	{
-		JsonObject &relay = hardware["relay" + String((i + 1))];
+		JsonObject relay = hardware["relay" + String((i + 1))];
 		activateTime[i] = relay["rtime"];
 		lockType[i] = relay["ltype"];
 		relayType[i] = relay["rtype"];

--- a/src/log.esp
+++ b/src/log.esp
@@ -1,9 +1,8 @@
-void extern mqtt_publish_event(JsonObject *root);
+void extern mqtt_publish_event(JsonDocument *root);
 
 void ICACHE_FLASH_ATTR writeEvent(String type, String src, String desc, String data)
 {
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["type"] = type;
 	root["src"] = src;
 	root["desc"] = desc;
@@ -18,7 +17,7 @@ void ICACHE_FLASH_ATTR writeEvent(String type, String src, String desc, String d
 	else // log to file
 	{
 		File eventlog = SPIFFS.open("/eventlog.json", "a");
-		root.printTo(eventlog);
+		serializeJson(root, eventlog);
 		eventlog.print("\n");
 		eventlog.close();
 	}
@@ -29,8 +28,7 @@ void ICACHE_FLASH_ATTR writeEvent(String type, String src, String desc, String d
 
 void ICACHE_FLASH_ATTR writeLatest(String uid, String username, int acctype)
 {
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["uid"] = uid;
 	root["username"] = username;
 	root["acctype"] = acctype;
@@ -43,7 +41,7 @@ void ICACHE_FLASH_ATTR writeLatest(String uid, String username, int acctype)
 	else // log to file
 	{
 		File latestlog = SPIFFS.open("/latestlog.json", "a");
-		root.printTo(latestlog);
+		serializeJson(root, latestlog);
 		latestlog.print("\n");
 		latestlog.close();
 	}
@@ -65,14 +63,15 @@ void ICACHE_FLASH_ATTR sendLogFile(int page, String fileName, int logFileType)
 	if (page == 1)
 		lastPos = 0;
 	float pages;
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	Serial.println("sendLogFile");
+	Serial.println(ESP.getFreeHeap());
+	DynamicJsonDocument root(2048);
 	if (logFileType == LOGTYPE_EVENTLOG)
 		root["command"] = "eventlist";
 	if (logFileType == LOGTYPE_LATESTLOG)
 		root["command"] = "latestlist";
 	root["page"] = page;
-	JsonArray &items = root.createNestedArray("list");
+	JsonArray items = root.createNestedArray("list");
 
 	File logFile;
 
@@ -116,11 +115,11 @@ void ICACHE_FLASH_ATTR sendLogFile(int page, String fileName, int logFileType)
 
 	logFile.close();
 	root["haspages"] = ceil(pages);
-	size_t len = root.measureLength();
+	size_t len = measureJson(root);
 	AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 	if (buffer)
 	{
-		root.printTo((char *)buffer->get(), len + 1);
+		serializeJson(root, (char *)buffer->get(), len + 1);
 		ws.textAll(buffer);
 		if (logFileType == LOGTYPE_EVENTLOG)
 			ws.textAll("{\"command\":\"result\",\"resultof\":\"eventlist\",\"result\": true}");
@@ -224,11 +223,10 @@ void ICACHE_FLASH_ATTR logMaintenance(String action, String filename)
 void ICACHE_FLASH_ATTR sendFileList(int page)
 {
 
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["command"] = "listfiles";
 	root["page"] = page;
-	JsonArray &items = root.createNestedArray("list");
+	JsonArray items = root.createNestedArray("list");
 
 	size_t first = (page - 1) * FILES_PER_PAGE;
 	size_t last = page * FILES_PER_PAGE;
@@ -245,7 +243,7 @@ void ICACHE_FLASH_ATTR sendFileList(int page)
 		{
 			if (numFiles >= first && numFiles < last)
 			{
-				JsonObject &item = items.createNestedObject();
+				JsonObject item = items.createNestedObject();
 				item["filename"] = dir.fileName();
 				item["filesize"] = dir.fileSize();
 			} // first, last
@@ -256,11 +254,11 @@ void ICACHE_FLASH_ATTR sendFileList(int page)
 	float pages = numFiles / FILES_PER_PAGE;
 	root["haspages"] = ceil(pages);
 
-	size_t len = root.measureLength();
+	size_t len = measureJson(root);
 	AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 	if (buffer)
 	{
-		root.printTo((char *)buffer->get(), len + 1);
+		serializeJson(root, (char *)buffer->get(), len + 1);
 		ws.textAll(buffer);
 		ws.textAll("{\"command\":\"result\",\"resultof\":\"listfiles\",\"result\": true}");
 	}

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -51,15 +51,14 @@ void mqtt_publish_boot(time_t boot_time)
 {
 	String stopic(mqttTopic);
 	stopic = stopic + "/send";
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["type"] = "boot";
 	root["time"] = boot_time;
 	root["uptime"] = "0";
 	root["ip"] = WiFi.localIP().toString();
 	root["hostname"] = deviceHostname;
 	String mqttBuffer_boot;
-	root.printTo(mqttBuffer_boot);
+	serializeJson(root, mqttBuffer_boot);
 	mqttClient.publish(stopic.c_str(), 0, false, mqttBuffer_boot.c_str());
 #ifdef DEBUG
 	Serial.print("[ INFO ] Mqtt Publish:");
@@ -73,11 +72,10 @@ void mqtt_publish_discovery()
 	String deviceName = deviceHostname;
 
 	String topic;
-	DynamicJsonBuffer jsonBuffer;
+	DynamicJsonDocument jsonBuffer(512);
 	String mqttBuffer;
 
-	DynamicJsonBuffer jsonBufferVia;
-	JsonObject &via = jsonBufferVia.createObject();
+	DynamicJsonDocument via(512);
 	via["ids"] = WiFi.macAddress();
 
 	for (int i = 0; i < 6; i++)
@@ -88,13 +86,12 @@ void mqtt_publish_discovery()
 		{
 		case 0:
 		{
-			DynamicJsonBuffer jsonBufferDevice;
-			JsonObject &dev = jsonBufferDevice.createObject();
+			DynamicJsonDocument dev(512);
 			dev["ids"] = WiFi.macAddress();
 			dev["name"] = deviceHostname;
 			dev["mf"] = "esp-rfid";
 			dev["sw"] = VERSION;
-			JsonObject &root = jsonBuffer.createObject();
+			DynamicJsonDocument root(512);
 			topic = "homeassistant/lock/" + deviceName + "/config";
 			root["name"] = "Lock";
 			root["uniq_id"] = deviceName + "/lock";
@@ -104,12 +101,12 @@ void mqtt_publish_discovery()
 			root["pl_lock"] = "{cmd:'opendoor'}";
 			root["avty_t"] = mtopic + "/avty";
 			root["dev"] = dev;
-			root.printTo(mqttBuffer);
+			serializeJson(root, mqttBuffer);
 			break;
 		}
 		case 1:
 		{
-			JsonObject &door = jsonBuffer.createObject();
+			DynamicJsonDocument door(512);
 			topic = "homeassistant/binary_sensor/" + deviceName + "/door/config";
 			door["name"] = "Door";
 			door["uniq_id"] = deviceName + "/door";
@@ -117,12 +114,12 @@ void mqtt_publish_discovery()
 			door["avty_t"] = mtopic + "/avty";
 			door["dev_cla"] = "door";
 			door["dev"] = via;
-			door.printTo(mqttBuffer);
+			serializeJson(door, mqttBuffer);
 			break;
 		}
 		case 2:
 		{
-			JsonObject &doorbell = jsonBuffer.createObject();
+			DynamicJsonDocument doorbell(512);
 			topic = "homeassistant/binary_sensor/" + deviceName + "/doorbell/config";
 			doorbell["name"] = "Doorbell";
 			doorbell["uniq_id"] = deviceName + "/doorbell";
@@ -131,12 +128,12 @@ void mqtt_publish_discovery()
 			doorbell["dev_cla"] = "sound";
 			doorbell["icon"] = "mdi:bell";
 			doorbell["dev"] = via;
-			doorbell.printTo(mqttBuffer);
+			serializeJson(doorbell, mqttBuffer);
 			break;
 		}
 		case 3:
 		{
-			JsonObject &tag = jsonBuffer.createObject();
+			DynamicJsonDocument tag(512);
 			topic = "homeassistant/sensor/" + deviceName + "/tag/config";
 			tag["name"] = "Tag";
 			tag["uniq_id"] = deviceName + "/tag";
@@ -146,12 +143,12 @@ void mqtt_publish_discovery()
 			tag["json_attr_t"] = mtopic + "/tag";
 			tag["icon"] = "mdi:key";
 			tag["dev"] = via;
-			tag.printTo(mqttBuffer);
+			serializeJson(tag, mqttBuffer);
 			break;
 		}
 		case 4:
 		{
-			JsonObject &user = jsonBuffer.createObject();
+			DynamicJsonDocument user(512);
 			topic = "homeassistant/sensor/" + deviceName + "/user/config";
 			user["name"] = "User";
 			user["uniq_id"] = deviceName + "/name";
@@ -161,12 +158,12 @@ void mqtt_publish_discovery()
 			user["json_attr_t"] = mtopic + "/tag";
 			user["icon"] = "mdi:human";
 			user["dev"] = via;
-			user.printTo(mqttBuffer);
+			serializeJson(user, mqttBuffer);
 			break;
 		}
 		case 5:
 		{
-			JsonObject &tamper = jsonBuffer.createObject();
+			DynamicJsonDocument tamper(512);
 			topic = "homeassistant/binary_sensor/" + deviceName + "/tamper/config";
 			tamper["name"] = "Door tamper";
 			tamper["uniq_id"] = deviceName + "/tamper";
@@ -175,7 +172,7 @@ void mqtt_publish_discovery()
 			tamper["dev_cla"] = "safety";
 			//tamper["icon"] = "mdi:bell";
 			tamper["dev"] = via;
-			tamper.printTo(mqttBuffer);
+			serializeJson(tamper, mqttBuffer);
 			break;
 		}
 		}
@@ -203,10 +200,9 @@ void mqtt_publish_avty()
 void mqtt_publish_heartbeat(time_t heartbeat, time_t uptime)
 {
 	String stopic(mqttTopic);
-	DynamicJsonBuffer jsonBuffer;
+	DynamicJsonDocument root(512);
 
 	stopic = stopic + "/send";
-	JsonObject &root = jsonBuffer.createObject();
 	root["type"] = "heartbeat";
 	root["time"] = heartbeat;
 	root["uptime"] = uptime;
@@ -214,7 +210,7 @@ void mqtt_publish_heartbeat(time_t heartbeat, time_t uptime)
 	root["hostname"] = deviceHostname;
 
 	String mqttBuffer8;
-	root.printTo(mqttBuffer8);
+	serializeJson(root, mqttBuffer8);
 	mqttClient.publish(stopic.c_str(), 0, false, mqttBuffer8.c_str());
 #ifdef DEBUG
 	Serial.print("[ INFO ] Mqtt Publish:");
@@ -235,8 +231,7 @@ void mqtt_publish_access(time_t accesstime, String const &isknown, String const 
 		{
 			stopic = stopic + "/tag";
 		}
-		DynamicJsonBuffer jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		DynamicJsonDocument root(512);
 		// log to MQTT adding cmd command
 		if (mqttEvents)
 		{
@@ -260,7 +255,7 @@ void mqtt_publish_access(time_t accesstime, String const &isknown, String const 
 			root["time"] = accesstime;
 		}
 		String mqttBuffer;
-		root.printTo(mqttBuffer);
+		serializeJson(root, mqttBuffer);
 		mqttClient.publish(stopic.c_str(), 0, false, mqttBuffer.c_str());
 #ifdef DEBUG
 		Serial.print("[ INFO ] Mqtt Publish:");
@@ -285,14 +280,14 @@ void mqtt_publish_io(String const &io, String const &state)
 	}
 }
 
-void mqtt_publish_event(JsonObject *root)
+void mqtt_publish_event(JsonDocument *root)
 {
 	if (mqttClient.connected())
 	{
 		String stopic(mqttTopic);
 		stopic = stopic + "/send";
 		String mqttBuffer;
-		root->printTo(mqttBuffer);
+		serializeJson(*root, mqttBuffer);
 		mqttClient.publish(stopic.c_str(), 0, false, mqttBuffer.c_str());
 	}
 }
@@ -309,16 +304,15 @@ void ICACHE_FLASH_ATTR getUserList(int todo)
 		stopic = stopic + "/accesslist";
 	else if (todo == 1) // Just for List
 		stopic = stopic + "/send";
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
-	JsonArray &users = root.createNestedArray("list");
+	DynamicJsonDocument root(512);
+	JsonArray users = root.createNestedArray("list");
 	Dir dir = SPIFFS.openDir("/P/");
 #ifdef DEBUG
 	Serial.println("[ INFO ] getUserList");
 #endif
 	while (dir.next())
 	{
-		JsonObject &item = users.createNestedObject();
+		JsonObject item = users.createNestedObject();
 		String uid = dir.fileName();
 		uid.remove(0, 3);
 		item["uid"] = uid;
@@ -326,15 +320,15 @@ void ICACHE_FLASH_ATTR getUserList(int todo)
 		size_t size = f.size();
 		std::unique_ptr<char[]> buf(new char[size]);
 		f.readBytes(buf.get(), size);
-		DynamicJsonBuffer jsonBuffer2;
-		JsonObject &json = jsonBuffer2.parseObject(buf.get());
-		if (json.success())
+		DynamicJsonDocument json(512);
+		auto error = deserializeJson(json, buf.get());
+		if (!error)
 		{
 
 			if (mqttClient.connected())
 			{
 				String mqttBuffer;
-				json.printTo(mqttBuffer);
+				serializeJson(json, mqttBuffer);
 				mqttClient.publish(stopic.c_str(), 0, false, mqttBuffer.c_str());
 #ifdef DEBUG
 				Serial.print("[ INFO ] Mqtt Publish:");
@@ -389,14 +383,14 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 	} else {
 		return;
 	}
-	StaticJsonBuffer<512> jsonBuffer;
 #ifdef DEBUG
 	Serial.print("[ INFO ] JSON msg: ");
 	Serial.println(mqttBuffer);
 #endif
 
-	JsonObject &root = jsonBuffer.parseObject(mqttBuffer);
-	if (!root.success())
+	StaticJsonDocument<512> root;
+	auto error = deserializeJson(root, mqttBuffer);
+	if (error)
 	{
 #ifdef DEBUG
 		Serial.print("[ INFO ] Failed parse MQTT message: ");
@@ -500,7 +494,7 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 		// Check if we created the file
 		if (f)
 		{
-			root.printTo(f);
+			serializeJson(root, f);
 		}
 		f.close();
 		return;

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -276,9 +276,9 @@ void ICACHE_FLASH_ATTR rfidloop()
 		size_t size = f.size();
 		std::unique_ptr<char[]> buf(new char[size]);
 		f.readBytes(buf.get(), size);
-		DynamicJsonBuffer jsonBuffer;
-		JsonObject &json = jsonBuffer.parseObject(buf.get());
-		if (json.success())
+		DynamicJsonDocument json(512);
+		auto error = deserializeJson(json, buf.get());
+		if (!error)
 		{
 
 			for (int currentRelay = 0; currentRelay < numRelays; currentRelay++)
@@ -370,19 +370,18 @@ void ICACHE_FLASH_ATTR rfidloop()
 					}
 				}
 				writeLatest(uid, username, AccType);
-				DynamicJsonBuffer jsonBuffer2;
-				JsonObject &root = jsonBuffer2.createObject();
+				DynamicJsonDocument root(512);
 				root["command"] = "piccscan";
 				root["uid"] = uid;
 				root["type"] = type;
 				root["known"] = 1;
 				root["acctype"] = AccType;
 				root["user"] = username;
-				size_t len = root.measureLength();
+				size_t len = measureJson(root);
 				AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 				if (buffer)
 				{
-					root.printTo((char *)buffer->get(), len + 1);
+					serializeJson(root, (char *)buffer->get(), len + 1);
 					ws.textAll(buffer);
 				}
 			}
@@ -402,17 +401,16 @@ void ICACHE_FLASH_ATTR rfidloop()
 		data += " " + String(type);
 		writeEvent("WARN", "rfid", "Unknown rfid tag is scanned", data);
 		writeLatest(uid, "Unknown", 98);
-		DynamicJsonBuffer jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		DynamicJsonDocument root(512);
 		root["command"] = "piccscan";
 		root["uid"] = uid;
 		root["type"] = type;
 		root["known"] = 0;
-		size_t len = root.measureLength();
+		size_t len = measureJson(root);
 		AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 		if (buffer)
 		{
-			root.printTo((char *)buffer->get(), len + 1);
+			serializeJson(root, (char *)buffer->get(), len + 1);
 			ws.textAll(buffer);
 		}
 		if (mqttEnabled)

--- a/src/websocket.esp
+++ b/src/websocket.esp
@@ -1,20 +1,18 @@
 void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 {
 	// We should always get a JSON object (stringfied) from browser, so parse it
-	DynamicJsonBuffer jsonBuffer;
-	//JsonObject &root = jsonBuffer.parseObject(msg);
+	DynamicJsonDocument root(4096);
 	char json[sz + 1];
 	memcpy(json, (char *)(client->_tempObject), sz);
 	json[sz] = '\0';
-	JsonObject &root = jsonBuffer.parseObject(json);
-	if (!root.success())
+	auto error = deserializeJson(root, json);
+	if (error)
 	{
 #ifdef DEBUG
 		Serial.println(F("[ WARN ] Couldn't parse WebSocket message"));
 #endif
 		free(client->_tempObject);
 		client->_tempObject = NULL;
-		//delete client->_tempObject;
 		return;
 	}
 	// Web Browser sends some commands, check which command is given
@@ -32,8 +30,8 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		File f = SPIFFS.open("/config.json", "w+");
 		if (f)
 		{
-			size_t len = root.measurePrettyLength();
-			root.prettyPrintTo(f);
+			size_t len = measureJsonPretty(root);
+			serializeJsonPretty(root, f);
 			//f.print(msg);
 			f.close();
 			shouldReboot = true;
@@ -93,9 +91,7 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 	{
 #ifdef DEBUG
 		Serial.println(F("[ DEBUG ] userfile received"));
-		String st = String();
-		root.printTo(st);
-		Serial.println(st);
+		serializeJson(root, Serial);
 #endif
 		const char *uid = root["uid"];
 		String filename = "/P/";
@@ -104,8 +100,7 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		// Check if we created the file
 		if (f)
 		{
-			//f.print(msg);
-			root.printTo(f);
+			serializeJson(root, f);
 #ifdef DEBUG
 		Serial.println(F("[ DEBUG ] userfile saved"));
 #endif

--- a/src/wsResponses.esp
+++ b/src/wsResponses.esp
@@ -1,10 +1,9 @@
 void ICACHE_FLASH_ATTR sendUserList(int page, AsyncWebSocketClient *client)
 {
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(4096);
 	root["command"] = "userlist";
 	root["page"] = page;
-	JsonArray &users = root.createNestedArray("list");
+	JsonArray users = root.createNestedArray("list");
 	Dir dir = SPIFFS.openDir("/P/");
 	int first = (page - 1) * 15;
 	int last = page * 15;
@@ -13,7 +12,7 @@ void ICACHE_FLASH_ATTR sendUserList(int page, AsyncWebSocketClient *client)
 	{
 		if (i >= first && i < last)
 		{
-			JsonObject &item = users.createNestedObject();
+			JsonObject item = users.createNestedObject();
 			String uid = dir.fileName();
 			uid.remove(0, 3);
 			item["uid"] = uid;
@@ -21,9 +20,9 @@ void ICACHE_FLASH_ATTR sendUserList(int page, AsyncWebSocketClient *client)
 			size_t size = f.size();
 			std::unique_ptr<char[]> buf(new char[size]);
 			f.readBytes(buf.get(), size);
-			DynamicJsonBuffer jsonBuffer2;
-			JsonObject &json = jsonBuffer2.parseObject(buf.get());
-			if (json.success())
+			DynamicJsonDocument json(512);
+			auto error = deserializeJson(json, buf.get());
+			if (!error)
 			{
 				String username = json["user"];
 				String pincode = json["pincode"];
@@ -47,11 +46,11 @@ void ICACHE_FLASH_ATTR sendUserList(int page, AsyncWebSocketClient *client)
 	}
 	float pages = i / 15.0;
 	root["haspages"] = ceil(pages);
-	size_t len = root.measureLength();
+	size_t len = measureJson(root);
 	AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 	if (buffer)
 	{
-		root.printTo((char *)buffer->get(), len + 1);
+		serializeJson(root, (char *)buffer->get(), len + 1);
 		if (client)
 		{
 			client->text(buffer);
@@ -74,8 +73,7 @@ void ICACHE_FLASH_ATTR sendStatus()
 		Serial.print(F("[ WARN ] Error getting info on SPIFFS"));
 #endif
 	}
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["command"] = "status";
 #ifdef OFFICIALBOARD
 	root["board"] = "brdV2";
@@ -116,11 +114,11 @@ void ICACHE_FLASH_ATTR sendStatus()
 	root["gateway"] = printIP(gwaddr);
 	root["netmask"] = printIP(nmaddr);
 
-	size_t len = root.measureLength();
+	size_t len = measureJson(root);
 	AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 	if (buffer)
 	{
-		root.printTo((char *)buffer->get(), len + 1);
+		serializeJson(root, (char *)buffer->get(), len + 1);
 		ws.textAll(buffer);
 	}
 }
@@ -146,13 +144,12 @@ void ICACHE_FLASH_ATTR printScanResult(int networksFound)
 			}
 		}
 	}
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["command"] = "ssidlist";
-	JsonArray &scan = root.createNestedArray("list");
+	JsonArray scan = root.createNestedArray("list");
 	for (int i = 0; i < 5 && i < networksFound; ++i)
 	{
-		JsonObject &item = scan.createNestedObject();
+		JsonObject item = scan.createNestedObject();
 		item["ssid"] = WiFi.SSID(indices[i]);
 		item["bssid"] = WiFi.BSSIDstr(indices[i]);
 		item["rssi"] = WiFi.RSSI(indices[i]);
@@ -160,11 +157,11 @@ void ICACHE_FLASH_ATTR printScanResult(int networksFound)
 		item["enctype"] = WiFi.encryptionType(indices[i]);
 		item["hidden"] = WiFi.isHidden(indices[i]) ? true : false;
 	}
-	size_t len = root.measureLength();
+	size_t len = measureJson(root);
 	AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len); //  creates a buffer (len + 1) for you.
 	if (buffer)
 	{
-		root.printTo((char *)buffer->get(), len + 1);
+		serializeJson(root, (char *)buffer->get(), len + 1);
 		ws.textAll(buffer);
 	}
 	WiFi.scanDelete();
@@ -172,16 +169,15 @@ void ICACHE_FLASH_ATTR printScanResult(int networksFound)
 
 void ICACHE_FLASH_ATTR sendTime()
 {
-	DynamicJsonBuffer jsonBuffer;
-	JsonObject &root = jsonBuffer.createObject();
+	DynamicJsonDocument root(512);
 	root["command"] = "gettime";
 	root["epoch"] = now();
 	root["timezone"] = timeZone;
-	size_t len = root.measureLength();
+	size_t len = measureJson(root);
 	AsyncWebSocketMessageBuffer *buffer = ws.makeBuffer(len);
 	if (buffer)
 	{
-		root.printTo((char *)buffer->get(), len + 1);
+		serializeJson(root, (char *)buffer->get(), len + 1);
 		ws.textAll(buffer);
 	}
 }


### PR DESCRIPTION
This PR upgrades to ArduinoJSON v6, which has substantial changes in the memory management. There's no more dynamic allocation:

> [DynamicJsonDocument](https://arduinojson.org/v6/api/dynamicjsondocument/) has a fixed capacity that you must specify to the constructor. Unlike the DynamicJsonBuffer, [DynamicJsonDocument](https://arduinojson.org/v6/api/dynamicjsondocument/) doesn’t automatically expand.

I'm doing this update to change the configuration management in order to better support wifi reconnections and fallback AP mode. As this v6 simplifies the management and parsing of JSON I thought it was worth the upgrade.

I've tried to test all the messages that I could and it worked fine. Fine as in I'm getting the same exceptions after a few clicks in the UI, but I think it's a memory leak in the web server somewhere, hopefully that's coming next in the fixes :)

The heap is used a bit more than before, but still it never runs out. I've tested with a lot of pages of logs and looks like it's working as intended. Also the heap fragmentation looked stable to me. The crashes that we experience in the web UI I think come from somewhere else. But I'll work on that on a separate PR.