### PR TITLE
Extract MQTT message processing

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ lib_deps =
   ESPAsyncUDP
   ESP Async WebServer
   ;https://github.com/me-no-dev/ESPAsyncWebServer#e4950444c41f082c1e040aca97034c3f53c8562c
-  AsyncMqttClient@0.8.2
+  AsyncMqttClient@0.9.0
   https://github.com/miguelbalboa/rfid#ea7ee3f3daafd46d0c5b8438ba41147c384a1f0d
   ;https://github.com/monkeyboard/Wiegand-Protocol-Library-for-Arduino.git
   https://github.com/beikeland/Wiegand-Protocol-Library-for-Arduino.git

--- a/src/config.esp
+++ b/src/config.esp
@@ -234,13 +234,8 @@ bool ICACHE_FLASH_ATTR loadConfiguration()
 #ifdef DEBUG
 	Serial.println("[ INFO ] Trying to setup NTP Server");
 #endif
-	/*
-	IPAddress timeserverip;
-	WiFi.hostByName(ntpserver, timeserverip);
-	String ip = printIP(timeserverip);
-	writeEvent("INFO", "ntp", "Connecting NTP Server", ip);
-	*/
 	NTP.Ntp(ntpserver, timeZone, ntpinter * 60);
+
 	if (mqtt["enabled"] == 1)
 		mqttEnabled = true;
 	else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -477,5 +477,6 @@ void ICACHE_RAM_ATTR loop()
 #endif
 			}
 		}
+		processMqttMessage();
 	}
 }

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -1,4 +1,6 @@
 char mqttBuffer[512];
+StaticJsonDocument<512> incomingMqttMessage;
+bool mqttMessageToProcess = false;
 
 void connectToMqtt()
 {
@@ -395,8 +397,8 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 	Serial.println(mqttBuffer);
 #endif
 
-	JsonObject &root = jsonBuffer.parseObject(mqttBuffer);
-	if (!root.success())
+	auto error = deserializeJson(incomingMqttMessage, mqttBuffer);
+	if (error)
 	{
 #ifdef DEBUG
 		Serial.print("[ INFO ] Failed parse MQTT message: ");
@@ -409,9 +411,9 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 	{
 		// Check if IP was send with command because we only
 		// accept commands for this where sent IP is equal to device IP
-		if (root.containsKey("doorip"))
+		if (incomingMqttMessage.containsKey("doorip"))
 		{
-			const char *ipadr = root["doorip"];
+			const char *ipadr = incomingMqttMessage["doorip"];
 			String espIp = WiFi.localIP().toString();
 			if (!((strcmp(ipadr, espIp.c_str()) == 0) && (ipadr != NULL)))
 			{
@@ -430,15 +432,21 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 		}
 	}
 
-	////////////////////////////////////////////////////////////
-	// CASE FOR MQTT
-	////////////////////////////////////////////////////////////
-	const char *command = root["cmd"];
-	// Check whatever the command is and act accordingly
+	mqttMessageToProcess = true;
+	return;
+}
+
+void processMqttMessage() {
+	if(!mqttMessageToProcess)
+	{
+		return;
+	}
+	mqttMessageToProcess = false;
+	const char *command = incomingMqttMessage["cmd"];
 	if (strcmp(command, "getuser") == 0)
 	{
 #ifdef DEBUG
-		Serial.println("[ MARE ] Get User List");
+		Serial.println("[ INFO ] Get User List");
 #endif
 		getUserList(0);
 		return;
@@ -479,7 +487,7 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 #ifdef DEBUG
 		Serial.println("[ INFO ] Delete a single user by uid");
 #endif
-		const char *uid = root["uid"];
+		const char *uid = incomingMqttMessage["uid"];
 		DeleteUserID(uid);
 		return;
 	}
@@ -489,18 +497,18 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
 
 #ifdef DEBUG
 		Serial.print("[ INFO ] Add Users: ");
-		const char *name = root["user"];
+		const char *name = incomingMqttMessage["user"];
 		Serial.println(name);
 #endif
 
-		const char *uid = root["uid"];
+		const char *uid = incomingMqttMessage["uid"];
 		String filename = "/P/";
 		filename += uid;
 		File f = SPIFFS.open(filename, "w+");
 		// Check if we created the file
 		if (f)
 		{
-			root.printTo(f);
+			serializeJson(incomingMqttMessage, f);
 		}
 		f.close();
 		return;

--- a/src/wifi.esp
+++ b/src/wifi.esp
@@ -39,8 +39,9 @@ void onWifiGotIP(const WiFiEventStationModeGotIP &event)
 #ifdef DEBUG
 	Serial.println(F("\n[ INFO ] WiFi IP Connected"));
 #endif
-	connectToMqtt();
-	//writeEvent("INFO", "wifi", "Connected with IP", "onWifiGotIP");
+	if (mqttEnabled) {
+		connectToMqtt();
+	}
 }
 
 bool ICACHE_FLASH_ATTR startAP(IPAddress apip, IPAddress apsubnet, int hid, const char *ssid, const char *password = NULL)
@@ -165,11 +166,6 @@ bool ICACHE_FLASH_ATTR connectSTA(const char *ssid, const char *password, byte b
 	if (WiFi.status() == WL_CONNECTED)
 	{
 		// Assume time is out first and check
-#ifdef DEBUG
-		//Serial.println();
-		Serial.print(F("[ INFO ] Client IP address: "));
-		Serial.println(WiFi.localIP());
-#endif
 		isWifiConnected = true;
 		String data = ssid;
 		data += " " + WiFi.localIP().toString();


### PR DESCRIPTION
This refactor is to address the problem that MQTT message processing was causing the ESP8266 to reboot, because of the timeout of the watchdog that make sure to go back to the system tasks, like taking care of wifi connection.

Also the MQTT library mentions this: https://github.com/marvinroger/async-mqtt-client/blob/develop/docs/1.-Getting-started.md#fully-featured-sketch

The point is to remove blocking code from the MQTT callback and moving it to the main loop. This alone solves all my stability issues. Meanwhile I've also upgraded to the latest client version, which solved another issue where I wasn't getting all the MQTT messages that I was seeing in the serial monitor.

This PR fixes for me #388, and also I cannot reproduce anymore the errors in #324 and probably also #312 is related to this.

Every time MQTT message processing was going over a time limit the board was resetting.