### PR TITLE
Trigger every relay on MQTT open door

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,7 @@ void ICACHE_RAM_ATTR loop()
 
 	if (currentMillis >= cooldown)
 	{
-		// rfidloop();
+		rfidloop();
 	}
 
 	for (int currentRelay = 0; currentRelay < config.numRelays; currentRelay++)

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -503,7 +503,10 @@ void processMqttMessage(MqttMessage *incomingMessage) {
 #endif
 		writeLatest(" ", "MQTT", 1);
 		mqtt_publish_access(now(), "true", "Always", "MQTT", " ");
-		activateRelay[0] = true;
+		for (int currentRelay = 0; currentRelay < config.numRelays; currentRelay++)
+		{
+			activateRelay[currentRelay] = true;
+		}
 		previousMillis = millis();
 	}
 


### PR DESCRIPTION
We should open all the doors, not just the first one when triggering the door opening via MQTT.