### PR TITLE
Wifi further improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,7 +112,6 @@ unsigned long openDoorMillis = 0;
 unsigned long previousLoopMillis = 0;
 unsigned long previousMillis = 0;
 bool shouldReboot = false;
-bool timerequest = false;
 unsigned long uptime = 0;
 unsigned long wifiPinBlink = millis();
 unsigned long wiFiUptimeMillis = 0;
@@ -301,12 +300,6 @@ void ICACHE_RAM_ATTR loop()
 		ESP.restart();
 	}
 
-	if (timerequest)
-	{
-		timerequest = false;
-		sendTime();
-	}
-
 	if (config.autoRestartIntervalSeconds > 0 && uptime > config.autoRestartIntervalSeconds * 1000)
 	{
 		writeEvent("WARN", "sys", "Auto restarting...", "");
@@ -330,7 +323,8 @@ void ICACHE_RAM_ATTR loop()
 		disableWifi();
 	}
 
-	if (doEnableWifi == true)
+	// don't try connecting to WiFi when waiting for pincode
+	if (doEnableWifi == true && keyTimer == 0)
 	{
 		writeEvent("INFO", "wifi", "Enabling WiFi", "");
 		doEnableWifi = false;

--- a/src/websocket.esp
+++ b/src/websocket.esp
@@ -140,13 +140,13 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 	}
 	else if (strcmp(command, "gettime") == 0)
 	{
-		timerequest = true;
+		sendTime();
 	}
 	else if (strcmp(command, "settime") == 0)
 	{
 		time_t t = root["epoch"];
 		setTime(t);
-		timerequest = true;
+		sendTime();
 	}
 	else if (strcmp(command, "getconf") == 0)
 	{

--- a/src/wifi.esp
+++ b/src/wifi.esp
@@ -9,9 +9,9 @@ void onWifiDisconnect(const WiFiEventStationModeDisconnected &event)
 	Serial.println(F("[ INFO ] WiFi STA Disconnected"));
 #endif
 	mqttReconnectTimer.detach();
-	if (!wifiReconnectTimer.active())
+	if (!wifiReconnectTimer.active() && !config.fallbackMode)
 	{
-		wifiReconnectTimer.once(60, setEnableWifi);
+		wifiReconnectTimer.once(300, setEnableWifi);
 	}
 	ledWifiOff();
 }
@@ -126,7 +126,7 @@ bool ICACHE_FLASH_ATTR connectSTA(const char *ssid, const char *password, byte b
 		WiFi.begin(ssid, password);
 	}
 	unsigned long now = millis();
-	uint8_t timeout = 30; // define when to time out in seconds
+	uint8_t timeout = 15; // define when to time out in seconds
 	do
 	{
 		ledWifiStatus();
@@ -158,7 +158,7 @@ bool ICACHE_FLASH_ATTR connectSTA(const char *ssid, const char *password, byte b
 #endif
 		if (!config.fallbackMode)
 		{
-			wifiReconnectTimer.once(60, setEnableWifi);
+			wifiReconnectTimer.once(300, setEnableWifi);
 		}
 		return false;
 	}
@@ -168,6 +168,7 @@ void ICACHE_FLASH_ATTR disableWifi()
 {
 	wiFiUptimeMillis = 0;
 	WiFi.disconnect(true);
+	WiFi.softAPdisconnect(true);
 #ifdef DEBUG
 	Serial.println(F("Turn wifi off."));
 #endif


### PR DESCRIPTION
I have changed a bit the default timeouts for wifi connections. The issue is that when the connection is retrying, then everything else is blocked, because the testing is happening in the main loop with a call to delay. So changing these timings will reduce the problem overall.

A proper fix would need to be implemented in a completely different way, avoiding the call to delay, which I would like to try avoiding as it would need a major rewrite of the wifi again :)

Then this: https://github.com/esprfid/esp-rfid/compare/dev...wifi-2?expand=1#diff-9d32a6cca07becc2b3812b46b3bd0d6636f58eddfb52b5cf70aeb70d11b260dfR171 should fix #319 