### PR TITLE
platformio.ini: use common for most settings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -3,6 +3,13 @@ default_envs = generic
 
 [common]
 platform = espressif8266@2.3.2
+f_cpu = 160000000L
+framework = arduino
+board = esp12e
+build_flags = 	-Wl,-Teagle.flash.4m2m.ld
+src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
+upload_speed = 460800
+monitor_speed = 9600
 lib_deps =
   ArduinoJson@6.19.1
   ESPAsyncTCP
@@ -16,44 +23,44 @@ lib_deps =
 
 ; boards which GPIO0 and RESET controlled using two NPN transistors as nodemcu devkit (includes wemos d1 mini)
 [env:generic]
-board_build.f_cpu = 160000000L
+board_build.f_cpu = ${common.f_cpu}
 platform = ${common.platform}
-framework = arduino
-board = esp12e
+framework = ${common.framework}
+board = ${common.board}
 ;upload_resetmethod = nodemcu
 lib_deps = ${common.lib_deps}
 extra_scripts = scripts/GENdeploy.py
-build_flags = -Wl,-Teagle.flash.4m2m.ld
-src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
+build_flags = ${common.build_flags}
+src_build_flags = ${common.src_build_flags}
 ;https://github.com/platformio/platform-espressif8266/issues/153
-upload_speed = 460800
-monitor_speed = 9600
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}
 board_build.flash_mode = dio
 
 ; official ESP-RFID board (V2)
 [env:relayboard]
-board_build.f_cpu = 160000000L
+board_build.f_cpu = ${common.f_cpu}
 platform = ${common.platform}
-framework = arduino
-board = esp12e
+framework = ${common.framework}
+board = ${common.board}
 lib_deps = ${common.lib_deps}
-build_flags = 	-Wl,-Teagle.flash.4m2m.ld
+build_flags = ${common.build_flags}
 		-DOFFICIALBOARD
-src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
+src_build_flags = ${common.src_build_flags}
 extra_scripts = scripts/OBdeploy.py
-upload_speed = 460800
-monitor_speed = 9600
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}
 
 ; generic firmware for debugging purposes
 [env:debug]
-board_build.f_cpu = 160000000L
+board_build.f_cpu = ${common.f_cpu}
 platform = ${common.platform}
-framework = arduino
-board = esp12e
+framework = ${common.framework}
+board = ${common.board}
 lib_deps = ${common.lib_deps}
-build_flags = 	-Wl,-Teagle.flash.4m2m.ld
+build_flags = ${common.build_flags}
 		-DDEBUG
-src_build_flags = !echo "-DBUILD_TAG="$TRAVIS_TAG
+src_build_flags = ${common.src_build_flags}
 extra_scripts = scripts/DBGdeploy.py
-upload_speed = 460800
-monitor_speed = 9600
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}


### PR DESCRIPTION
This way it's much easier to see what changes between the three
environments, instead of comparing magic numbers wondering if they
change you can just glance at it and see the things that are different.
