### PR TITLE
support max open time=0

### DIFF
--- a/src/door.esp
+++ b/src/door.esp
@@ -42,7 +42,7 @@ void doorStatus(/* arguments */)
     mqttPublishIo("door", "ON");
     lastDoorState = 0;
   }
-  if ((lastDoorState == 0) && (lastTamperState == 0))
+  if (config.maxOpenDoorTime != 0 && (lastDoorState == 0) && (lastTamperState == 0))
 	{
 		if (currentMillis - openDoorMillis >= config.maxOpenDoorTime*1000)
 		{


### PR DESCRIPTION
The tooltip for max open time says "If set to zero - does not apply"
But it does, so this changes it to not apply.
