### PR TITLE
fix: close relays at startup after we load config

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,6 +184,10 @@ void ICACHE_FLASH_ATTR setup()
 
 	bool configured = false;
 	configured = loadConfiguration(config);
+	// set relays to closed now that we know the config
+	for (int currentRelay = 0; currentRelay < config.numRelays; currentRelay++) {
+		digitalWrite(config.relayPin[currentRelay], !config.relayType[currentRelay]);
+	}
 	setupMqtt();
 	setupWebServer();
 	setupWifi(configured);


### PR DESCRIPTION
If you aren't using OFFICIALBOARD and your relay isn't active high on
pin 13 it will be left open on startup.

I feel like this is inconsistant because I thought it was working a few days ago
but all the commits I might have had running don't lock my test door controller,
so I dunno.
