### PR TITLE
Remove officialboard build flag

### DIFF
--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -20,7 +20,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run Platformio builds
       run: |
-        platformio run -e generic -e relayboard -e debug
+        platformio run -e generic -e debug
     - name: Export bins
       uses: actions/upload-artifact@v2
       with:

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,20 +37,6 @@ upload_speed = ${common.upload_speed}
 monitor_speed = ${common.monitor_speed}
 board_build.flash_mode = dio
 
-; official ESP-RFID board (V2)
-[env:relayboard]
-board_build.f_cpu = ${common.f_cpu}
-platform = ${common.platform}
-framework = ${common.framework}
-board = ${common.board}
-lib_deps = ${common.lib_deps}
-build_flags = ${common.build_flags}
-		-DOFFICIALBOARD
-src_build_flags = ${common.src_build_flags}
-extra_scripts = scripts/OBdeploy.py
-upload_speed = ${common.upload_speed}
-monitor_speed = ${common.monitor_speed}
-
 ; generic firmware for debugging purposes
 [env:debug]
 board_build.f_cpu = ${common.f_cpu}

--- a/src/PN532.cpp
+++ b/src/PN532.cpp
@@ -1,4 +1,3 @@
-#ifndef OFFICIALBOARD
 /**************************************************************************
     @file     PN532.cpp
     @author   Adafruit Industries, Elmü
@@ -1034,5 +1033,3 @@ byte PN532::SpiRead(void)
     }
 #endif
 }
-
-#endif

--- a/src/config.esp
+++ b/src/config.esp
@@ -112,11 +112,6 @@ bool ICACHE_FLASH_ATTR loadConfiguration(Config &config)
 	else
 		config.numRelays = 1;
 
-#ifdef OFFICIALBOARD
-	config.pinCodeRequested = hardware["pincoderequested"];
-	setupWiegandReader(5, 4);
-#endif
-#ifndef OFFICIALBOARD
 	config.readertype = hardware["readertype"];
 	int rfidss;
 	if (config.readertype == READER_WIEGAND || config.readertype == READER_WIEGAND_RDM6300)
@@ -145,7 +140,6 @@ bool ICACHE_FLASH_ATTR loadConfiguration(Config &config)
 	if (config.readertype > 2)
 		Serial.begin(9600);
 #endif
-#endif
 	config.fallbackMode = network["fallbackmode"] == 1;
 	config.autoRestartIntervalSeconds = general["restart"];
 	config.wifiTimeout = network["offtime"];
@@ -160,7 +154,6 @@ bool ICACHE_FLASH_ATTR loadConfiguration(Config &config)
 	config.lockType[0] = hardware["ltype"];
 	config.relayType[0] = hardware["rtype"];
 
-#ifndef OFFICIALBOARD
 	config.relayPin[0] = hardware["rpin"];
 	pinMode(config.relayPin[0], OUTPUT);
 	digitalWrite(config.relayPin[0], !config.relayType[0]);
@@ -176,7 +169,6 @@ bool ICACHE_FLASH_ATTR loadConfiguration(Config &config)
 		digitalWrite(config.relayPin[i], !config.relayType[i]);
 	}
 
-#endif
 	config.ssid = strdup(network["ssid"]);
 	config.wifiPassword = strdup(network["pswd"]);
 	config.accessPointMode = network["wmode"] == 1;

--- a/src/config.h
+++ b/src/config.h
@@ -1,9 +1,5 @@
 struct Config {
-#ifdef OFFICIALBOARD
-    int relayPin[MAX_NUM_RELAYS] = {13};
-#else
     int relayPin[MAX_NUM_RELAYS];
-#endif
     uint8_t accessdeniedpin = 255;
     bool accessPointMode = false;
     IPAddress accessPointIp;

--- a/src/magicnumbers.h
+++ b/src/magicnumbers.h
@@ -28,11 +28,7 @@
 
 // hardware defines
 
-#ifdef OFFICIALBOARD
-#define MAX_NUM_RELAYS 1
-#else
 #define MAX_NUM_RELAYS 4
-#endif
 
 #define LOCKTYPE_MOMENTARY 0
 #define LOCKTYPE_CONTINUOUS 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,18 +42,6 @@ SOFTWARE.
 
 Config config;
 
-#ifdef OFFICIALBOARD
-
-#include <Wiegand.h>
-
-WIEGAND wg;
-bool activateRelay[MAX_NUM_RELAYS] = {false};
-bool deactivateRelay[MAX_NUM_RELAYS] = {false};
-
-#endif
-
-#ifndef OFFICIALBOARD
-
 #include <MFRC522.h>
 #include "PN532.h"
 #include <Wiegand.h>
@@ -67,8 +55,6 @@ RFID_Reader RFIDr;
 // relay specific variables
 bool activateRelay[MAX_NUM_RELAYS] = {false, false, false, false};
 bool deactivateRelay[MAX_NUM_RELAYS] = {false, false, false, false};
-
-#endif
 
 // these are from vendors
 #include "webh/glyphicons-halflings-regular.woff.gz.h"
@@ -132,13 +118,6 @@ unsigned long wiFiUptimeMillis = 0;
 
 void ICACHE_FLASH_ATTR setup()
 {
-#ifdef OFFICIALBOARD
-	// Set relay pin to LOW signal as early as possible
-	pinMode(13, OUTPUT);
-	digitalWrite(13, LOW);
-	delay(200);
-#endif
-
 #ifdef DEBUG
 	Serial.begin(9600);
 	Serial.println();

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -25,14 +25,10 @@ void loadWiegandData()
 
 void rfidPrepareRead()
 {
-#ifdef OFFICIALBOARD
-	loadWiegandData();
-#else
 	if (config.readertype == READER_WIEGAND)
 	{
 		loadWiegandData();
 	}
-#endif
 }
 
 void wiegandRead()
@@ -72,7 +68,6 @@ void wiegandRead()
 	}
 }
 
-#ifndef OFFICIALBOARD
 void mfrc522Read()
 {
 	if (!mfrc522.PICC_IsNewCardPresent() || !mfrc522.PICC_ReadCardSerial())
@@ -153,7 +148,6 @@ void genericRead()
 		pn532Read();
 	}
 }
-#endif
 
 void rfidRead()
 {
@@ -161,10 +155,6 @@ void rfidRead()
 	{
 		return;
 	}
-#ifdef OFFICIALBOARD
-	wiegandRead();
-#endif
-#ifndef OFFICIALBOARD
 	if (config.readertype == READER_MFRC522)
 	{
 		mfrc522Read();
@@ -181,17 +171,14 @@ void rfidRead()
 	{
 		genericRead();
 	}
-#endif
 }
 
 void pinCodeRead()
 {
-#ifndef OFFICIALBOARD
 	if (config.readertype != READER_WIEGAND)
 	{
 		return;
 	}
-#endif
 	if (rfidState != waitingForPincode || !config.pinCodeRequested || !wiegandAvailable)
 	{
 		return;
@@ -457,7 +444,6 @@ void rfidLoop()
 	cleanRfidLoop();
 }
 
-#ifndef OFFICIALBOARD
 #ifdef DEBUG
 void ICACHE_FLASH_ATTR ShowMFRC522ReaderDetails()
 {
@@ -481,14 +467,12 @@ void ICACHE_FLASH_ATTR ShowMFRC522ReaderDetails()
 	}
 }
 #endif
-#endif
 
 void ICACHE_FLASH_ATTR setupWiegandReader(int d0, int d1)
 {
 	wg.begin(d0, d1);
 }
 
-#ifndef OFFICIALBOARD
 void ICACHE_FLASH_ATTR setupMFRC522Reader(int rfidss, int rfidgain)
 {
 	SPI.begin();						 // MFRC522 Hardware uses SPI protocol
@@ -504,9 +488,7 @@ void ICACHE_FLASH_ATTR setupMFRC522Reader(int rfidss, int rfidgain)
 	ShowMFRC522ReaderDetails(); // Show details of PCD - MFRC522 Card Reader details
 #endif
 }
-#endif
 
-#ifndef OFFICIALBOARD
 void ICACHE_FLASH_ATTR setupPN532Reader(int rfidss)
 {
 	// init controller
@@ -540,4 +522,3 @@ void ICACHE_FLASH_ATTR setupPN532Reader(int rfidss)
 		}
 	} while (false);
 }
-#endif

--- a/src/websocket.esp
+++ b/src/websocket.esp
@@ -115,7 +115,6 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		previousMillis = millis();
 		ws.textAll("{\"command\":\"giveAccess\"}");
 	}
-#ifndef OFFICIALBOARD
 	else if (strcmp(command, "testrelay2") == 0)
 	{
 		activateRelay[1] = true;
@@ -134,7 +133,6 @@ void ICACHE_FLASH_ATTR procMsg(AsyncWebSocketClient *client, size_t sz)
 		previousMillis = millis();
 		ws.textAll("{\"command\":\"giveAccess\"}");
 	}
-#endif
 	else if (strcmp(command, "scan") == 0)
 	{
 		WiFi.scanNetworksAsync(printScanResult, true);

--- a/src/wsResponses.esp
+++ b/src/wsResponses.esp
@@ -75,9 +75,6 @@ void ICACHE_FLASH_ATTR sendStatus()
 	}
 	DynamicJsonDocument root(1024);
 	root["command"] = "status";
-#ifdef OFFICIALBOARD
-	root["board"] = "brdV2";
-#endif
 	root["heap"] = ESP.getFreeHeap();
 	root["chipid"] = String(ESP.getChipId(), HEX);
 	root["cpu"] = ESP.getCpuFreqMHz();


### PR DESCRIPTION
Following @nardev's comment here: https://github.com/esprfid/esp-rfid/pull/526#issuecomment-1183587999 I've dropped the support for `OFFICIALBOARD` build target.

This simplifies a bit the code and drops unused code anyways.

Please @nardev @omersiar can you confirm this is fine? Thanks!