### PR TITLE
Fix wrong logging

### DIFF
--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -404,7 +404,7 @@ void rfidOutsideMessaging()
 		ledAccessDeniedOn();
 		beeperAccessDenied();
 	}
-	if (uid != "")
+	if (uid != "" && processingState != waiting)
 	{
 		writeLatest(uid, username, accountType);
 		DynamicJsonDocument root(512);


### PR DESCRIPTION
This fixes unnecessary log messages when waiting for the pin code or when reading a new card to add it to the database