### PR TITLE
Improving WiFi/MQTT connection reliability

### DIFF
--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -12,10 +12,24 @@ MqttMessage *messageQueue = NULL;
 
 void connectToMqtt()
 {
+	if (!config.mqttEnabled) {
+		return;
+	}
 #ifdef DEBUG
 	Serial.println("[ INFO ] Connecting MQTT");
 #endif
 	mqttClient.connect();
+}
+
+void disconnectMqtt()
+{
+	if (!config.mqttEnabled) {
+		return;
+	}
+#ifdef DEBUG
+	Serial.println("[ INFO ] Disconnecting MQTT");
+#endif
+	mqttClient.disconnect(true);
 }
 
 void onMqttDisconnect(AsyncMqttClientDisconnectReason reason)

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -12,7 +12,7 @@ MqttMessage *messageQueue = NULL;
 
 void connectToMqtt()
 {
-	if (!config.mqttEnabled) {
+	if (!config.mqttEnabled || mqttClient.connected()) {
 		return;
 	}
 #ifdef DEBUG
@@ -23,7 +23,7 @@ void connectToMqtt()
 
 void disconnectMqtt()
 {
-	if (!config.mqttEnabled) {
+	if (!config.mqttEnabled || !mqttClient.connected()) {
 		return;
 	}
 #ifdef DEBUG
@@ -561,7 +561,7 @@ void processMqttQueue()
 
 void setupMqtt()
 {
-    if (!config.mqttEnabled)
+  if (!config.mqttEnabled)
 	{
 		return;
 	}

--- a/src/wifi.esp
+++ b/src/wifi.esp
@@ -3,8 +3,25 @@ void setEnableWifi()
 	doEnableWifi = true;
 }
 
+void onWifiConnect(const WiFiEventStationModeConnected &event)
+{
+#ifdef DEBUG
+	Serial.println(F("[ INFO ] WiFi STA Connected"));
+#endif
+	mqttReconnectTimer.detach();
+	if (!wifiReconnectTimer.active() && !config.fallbackMode)
+	{
+		wifiReconnectTimer.once(300, setEnableWifi);
+	}
+	ledWifiOff();
+}
+
 void onWifiDisconnect(const WiFiEventStationModeDisconnected &event)
 {
+	if ( !WiFi.isConnected() )
+	{
+		return;
+	}
 #ifdef DEBUG
 	Serial.println(F("[ INFO ] WiFi STA Disconnected"));
 #endif
@@ -200,6 +217,7 @@ void setupWifi(bool configured)
 		fallbacktoAPMode();
 	} else
 	{
+		wifiConnectHandler = WiFi.onStationModeConnected(onWifiConnect);
 		wifiDisconnectHandler = WiFi.onStationModeDisconnected(onWifiDisconnect);
 		wifiOnStationModeGotIPHandler = WiFi.onStationModeGotIP(onWifiGotIP);
 		WiFi.hostname(config.deviceHostname);

--- a/src/wifi.esp
+++ b/src/wifi.esp
@@ -9,6 +9,7 @@ void onWifiDisconnect(const WiFiEventStationModeDisconnected &event)
 	Serial.println(F("[ INFO ] WiFi STA Disconnected"));
 #endif
 	mqttReconnectTimer.detach();
+	disconnectMqtt();
 	if (!wifiReconnectTimer.active() && !config.fallbackMode)
 	{
 		wifiReconnectTimer.once(300, setEnableWifi);


### PR DESCRIPTION
The retry timer wasn't working properly as the onDisconnect is called every few seconds when it's not connected, so the timer wasn't effective in reconnecting.

With this PR I've changed a couple little things, but now it reconnects very well.

A bit more testing for long lasting connections would be good, if anyone can check and let me know, it would be great!