### PR TITLE
Using a SoftwareSerial to communicate with RDM6300

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,8 @@ The following table shows the typical pin layout used for connecting readers har
 | GPIO-13 | D7            | D0      | MOSI          | MOSI    |         |
 | GPIO-12 | D6            | D1      | MISO          | MISO    |         |
 | GPIO-14 | D5            |         | SCK           | SCK     |         |
-| GPIO-04 | D2            |         |               |         |         |
+| GPIO-04 | D2            |         |               |         | TX      |
 | GPIO-05 | D1            |         | SS            |         |         |
-| GPIO-03 | RX            |         |               |         | TX      |
 
 For Wiegand based readers, you can configure D0 and D1 pins via settings page. By default, D0 is GPIO-4 and D1 is GPIO-5
 

--- a/src/config.esp
+++ b/src/config.esp
@@ -141,6 +141,10 @@ bool ICACHE_FLASH_ATTR loadConfiguration(Config &config)
 		rfidss = hardware["sspin"];
 		setupPN532Reader(rfidss);
 	}
+	else if (config.readertype > READER_PN532)
+	{
+		setupRDM6300Reader();
+	}
 	config.fallbackMode = network["fallbackmode"] == 1;
 	config.autoRestartIntervalSeconds = general["restart"];
 	config.wifiTimeout = network["offtime"];

--- a/src/magicnumbers.h
+++ b/src/magicnumbers.h
@@ -26,6 +26,10 @@
 #define WIEGANDTYPE_PICC24 24
 #define WIEGANDTYPE_PICC34 34
 
+#define RDM6300_BAUDRATE 9600
+#define RDM6300_READ_TIMEOUT 20
+#define RDM6300_RX_PIN 4
+
 // hardware defines
 
 #define MAX_NUM_RELAYS 4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,11 +46,13 @@ Config config;
 #include "PN532.h"
 #include <Wiegand.h>
 #include "rfid125kHz.h"
+#include <SoftwareSerial.h>
 
 MFRC522 mfrc522 = MFRC522();
 PN532 pn532;
 WIEGAND wg;
 RFID_Reader RFIDr;
+SoftwareSerial *rdm6300_sw_serial = NULL;
 
 // relay specific variables
 bool activateRelay[MAX_NUM_RELAYS] = {false, false, false, false};

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -153,9 +153,9 @@ void pn532Read()
 
 void genericRead()
 {
-	while (Serial.available() > 0)
+	while (rdm6300_sw_serial->available() > 0)
 	{
-		RFIDr.rfidSerial(Serial.read());
+		RFIDr.rfidSerial(rdm6300_sw_serial->read());
 	}
 	if (RFIDr.Available())
 	{
@@ -565,4 +565,11 @@ void ICACHE_FLASH_ATTR setupPN532Reader(int rfidss)
 			break;
 		}
 	} while (false);
+}
+
+void ICACHE_FLASH_ATTR setupRDM6300Reader()
+{
+	rdm6300_sw_serial = new SoftwareSerial(RDM6300_RX_PIN, -1);
+	rdm6300_sw_serial->begin(RDM6300_BAUDRATE);
+	rdm6300_sw_serial->setTimeout(RDM6300_READ_TIMEOUT);
 }


### PR DESCRIPTION
RDM6300 needs a serial with 9600 baud, and the Hardware serial is set to 115200, creating a SoftwareSerial bound to GPIO-04 and using it to read the data from the board allows the program to use RDM6300 correctly.