### PR TITLE
RFID uid fix

### DIFF
--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -113,11 +113,13 @@ void mfrc522Read()
 #ifdef DEBUG
 	Serial.print(F("[ INFO ] PICC's UID: "));
 #endif
-	for (int i = 0; i < mfrc522.uid.size; ++i)
-	{
-		uid += String(mfrc522.uid.uidByte[mfrc522.uid.size - (i + 1)] < 0x10 ? "0" : "");
-		rfidState = cardSwiped;
-	}
+	for (byte i = 0; i < mfrc522.uid.size; i++) 
+ 	 {
+     		uid+=(String(mfrc522.uid.uidByte[i] < 0x10 ? "0" : ""));
+     		uid+=(String(mfrc522.uid.uidByte[i], HEX));
+  	}
+	rfidState = cardSwiped;
+
 #ifdef DEBUG
 	Serial.print(uid);
 #endif


### PR DESCRIPTION
Modified rfid.esp as current code was giving 0 uid's regardless this code works with uid's containing 0