### PR TITLE
don't process JSON past the end of the buffer

### DIFF
--- a/src/config.esp
+++ b/src/config.esp
@@ -12,7 +12,7 @@ bool ICACHE_FLASH_ATTR loadConfiguration(Config &config)
 	std::unique_ptr<char[]> buf(new char[size]);
 	configFile.readBytes(buf.get(), size);
 	DynamicJsonDocument json(2048);
-	auto error = deserializeJson(json, buf.get());
+	auto error = deserializeJson(json, buf.get(), size);
 	if (error)
 	{
 #ifdef DEBUG

--- a/src/mqtt.esp
+++ b/src/mqtt.esp
@@ -372,7 +372,7 @@ void getUserList()
 		std::unique_ptr<char[]> buf(new char[size]);
 		f.readBytes(buf.get(), size);
 		DynamicJsonDocument json(512);
-		auto error = deserializeJson(json, buf.get());
+		auto error = deserializeJson(json, buf.get(), size);
 		if (!error)
 		{
 			mqttPublishEvent(&json);

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -70,7 +70,7 @@ void wiegandRead()
 				f.readBytes(buf.get(), size);
 				f.close();
 				DynamicJsonDocument json(512);
-				auto error = deserializeJson(json, buf.get());
+				auto error = deserializeJson(json, buf.get(), size);
 				if (error)
 				{
 					processingState = notValid;
@@ -299,7 +299,8 @@ void rfidProcess()
 	f.readBytes(buf.get(), size);
 	f.close();
 	DynamicJsonDocument json(512);
-	auto error = deserializeJson(json, buf.get());
+	auto error = deserializeJson(json, buf.get(), size);
+
 	if (error)
 	{
 		processingState = notValid;

--- a/src/wsResponses.esp
+++ b/src/wsResponses.esp
@@ -21,7 +21,7 @@ void ICACHE_FLASH_ATTR sendUserList(int page, AsyncWebSocketClient *client)
 			std::unique_ptr<char[]> buf(new char[size]);
 			f.readBytes(buf.get(), size);
 			DynamicJsonDocument json(512);
-			auto error = deserializeJson(json, buf.get());
+			auto error = deserializeJson(json, buf.get(), size);
 			if (!error)
 			{
 				String username = json["user"];


### PR DESCRIPTION
The buffer that files are read into is not zero-terminated, but deserializeJson needs a zero-terminated string. It seems that deserializeJson normally stops when it's read a full JSON document hence it usually works fine, but it's possible (especially if a file is corrupt for some reason) that it could keep processing past the end of the file. deserialiseJson accepts an optional buffer size which saves having to extend the buffer for the extra \0 char.

There are some other cases of deserializeJson, but having looked at them it seems to me that they are operating on zero-terminated buffers, so are good as-is.