### PR TITLE
Fix activation logic for extra relays

### DIFF
--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -357,17 +357,25 @@ void rfidProcess()
 		processingState = notValid;
 	}
 
+	/*
+	 *  If user is valid and opening hour time is allowed, go through each relay
+	 *  in turn to see if it needs to be activated
+	 */
 	if (processingState == valid || processingState == validAdmin)
 	{
 		for (int currentRelay = 0; currentRelay < config.numRelays; currentRelay++)
 		{
+			// Get user data JSON access type entry for this relay
 			if (currentRelay == 0) {
-				activateRelay[currentRelay] = true;
 				accountTypes[currentRelay] = json["acctype"];
 			} else {
 				accountTypes[currentRelay] = json["acctype" + String(currentRelay + 1)];
-				activateRelay[currentRelay] = (accountTypes[currentRelay] == ACCESS_GRANTED);
 			}
+
+			// Enable activation if permissions are correct
+			activateRelay[currentRelay] = (accountTypes[currentRelay] == ACCESS_GRANTED);
+
+			// ...except Admin, which always activates everything
 			if (processingState == validAdmin)
 			{
 				activateRelay[currentRelay] = true;

--- a/src/rfid.esp
+++ b/src/rfid.esp
@@ -365,9 +365,8 @@ void rfidProcess()
 				activateRelay[currentRelay] = true;
 				accountTypes[currentRelay] = json["acctype"];
 			} else {
-				bool isRelayActive = accountTypes[currentRelay] == ACCESS_GRANTED;
-				activateRelay[currentRelay] = isRelayActive;
 				accountTypes[currentRelay] = json["acctype" + String(currentRelay + 1)];
+				activateRelay[currentRelay] = (accountTypes[currentRelay] == ACCESS_GRANTED);
 			}
 			if (processingState == validAdmin)
 			{


### PR DESCRIPTION
Existing code sets the activation flag, then finds out if it should be set or not. This means that for a relay configured as "continuous" it always lags behind by one activation. Swapping these over makes the relay work as expected each time it is activated.

Also simplifies the code slightly, there is no need to treat relay0 as special here; the previous code guarantees that it will already be ACCESS_GRANTED by the time it hits this loop.